### PR TITLE
Openssl cmake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ option(MINIROS_USE_SYSTEM_LZ4 "Use lz4 from system" OFF)
 option(MINIROS_BUILD_EXAMPLES "Build examples" ${MINIROS_ADDITIONAL_COMPONENTS})
 option(MINIROS_BUILD_TESTS "Build tests" ${MINIROS_ADDITIONAL_COMPONENTS})
 option(MINIROS_BUILD_SHARED_LIBS "Build shared version of miniros" ON)
+option(MINIROS_ROSBAG_USE_GPGME_ENCRYPTION "Use GPGME encryption support" OFF)
+option(MINIROS_ROSBAG_USE_OPENSSL_ENCRYPTION "Use openssl encryption for rosbag" OFF)
 
 # execinfo.h is needed for backtrace on glibc systems
 CHECK_INCLUDE_FILE(execinfo.h HAVE_EXECINFO_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 cmake_policy(SET CMP0077 NEW)
 
-project(miniros VERSION 0.2.1)
+project(miniros VERSION 0.2.2)
 
 
 include(CheckIncludeFile)

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>miniros</name>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <description>
     ROS CXX contains a stripped version of ROS C++ code.
     It should become a standalone ROS client without any complex external dependencies.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,17 +73,17 @@ set(ENCRYPT_SOURCE "")
 set(ENCRYPT_LIBRARIES "")
 
 # AES encryption plugin
-find_package(OpenSSL QUIET)
-if (OpenSSL_FOUND)
-	message(STATUS "Found OpenSSL include=${OPENSSL_INCLUDE_DIR}")
-	list(APPEND ENCRYPT_SOURCE "rosbag_storage/aes_encryptor.cpp")
-	list(APPEND ENCRYPT_LIBRARIES OpenSSL::Crypto)
-else ()
-	message(STATUS "No OpenSSL was found. Rosbag will not support AES encryption.")
+if (MINIROS_ROSBAG_USE_OPENSSL_ENCRYPTION)
+	find_package(OpenSSL QUIET)
+	if (OpenSSL_FOUND)
+		message(STATUS "Found OpenSSL include=${OPENSSL_INCLUDE_DIR}")
+		list(APPEND ENCRYPT_SOURCE "rosbag_storage/aes_encryptor.cpp")
+		list(APPEND ENCRYPT_LIBRARIES OpenSSL::Crypto)
+	else ()
+		message(STATUS "No OpenSSL was found. Rosbag will not support AES encryption.")
+	endif()
 endif()
 
-
-option(MINIROS_ROSBAG_USE_GPGME_ENCRYPTION "Use GPGME encryption support" OFF)
 
 if(MINIROS_ROSBAG_USE_GPGME_ENCRYPTION)
 	list(APPEND ENCRYPT_SOURCE "rosbag_storage/gpgme_utils.cpp")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(ENCRYPT_LIBRARIES "")
 # AES encryption plugin
 find_package(OpenSSL QUIET)
 if (OpenSSL_FOUND)
+	message(STATUS "Found OpenSSL include=${OPENSSL_INCLUDE_DIR}")
 	list(APPEND ENCRYPT_SOURCE "rosbag_storage/aes_encryptor.cpp")
 	list(APPEND ENCRYPT_LIBRARIES OpenSSL::Crypto)
 else ()
@@ -127,7 +128,7 @@ target_include_directories(bag_storage PRIVATE ${MINIROS_INCLUDE_DIRS} ${rosbag_
 target_compile_definitions(bag_storage PRIVATE rosbag_EXPORTS rosbag_storage_EXPORTS roslz4_EXPORTS)
 
 set_property(TARGET bag_storage PROPERTY CXX_STANDARD 17)
-target_link_libraries(bag_storage ${AES_ENCRYPT_LIBRARIES} ${rosbag_LIBS} roscxx)
+target_link_libraries(bag_storage ${ENCRYPT_LIBRARIES} ${rosbag_LIBS} roscxx)
 
 set(minibag_SRC
 	rosbag/encrypt.cpp


### PR DESCRIPTION
Fixed compile errors when openssl is available on windows. Current solution just allows to disable usage of OpenSSL even if find_package(OpenSSL) is found