### PR TITLE
Reduce singletonism

### DIFF
--- a/include/miniros/node_handle.h
+++ b/include/miniros/node_handle.h
@@ -2194,6 +2194,9 @@ if (service)  // Enter if advertised service is valid
    */
   bool ok() const;
 
+  TopicManagerPtr getTopicManager();
+  ServiceManagerPtr getServiceManager();
+
 private:
   struct no_validate { };
   // this is pretty awful, but required to preserve public interface (and make minimum possible changes)

--- a/include/miniros/publisher.h
+++ b/include/miniros/publisher.h
@@ -38,6 +38,7 @@
 
 namespace miniros
 {
+  class TopicManager;
   /**
    * \brief Manages an advertisement on a specific topic.
    *
@@ -72,7 +73,7 @@ namespace miniros
           return;
         }
 
-      if (!impl_->isValid())
+      if (!isValid())
         {
           MINIROS_ASSERT_MSG(false, "Call to publish() on an invalid Publisher (topic [%s])", impl_->topic_.c_str());
           return;
@@ -105,7 +106,7 @@ namespace miniros
           return;
         }
 
-      if (!impl_->isValid())
+      if (!isValid())
         {
           MINIROS_ASSERT_MSG(false, "Call to publish() on an invalid Publisher (topic [%s])", impl_->topic_.c_str());
           return;
@@ -119,6 +120,9 @@ namespace miniros
       SerializedMessage m;
       publishImpl([&message]() {return serializeMessage<M>(message);}, m);
     }
+
+    /// Check if subscriber is a valid object.
+    bool isValid() const;
 
     /**
      * \brief Shutdown the advertisement associated with this Publisher
@@ -147,7 +151,7 @@ namespace miniros
      */
     bool isLatched() const;
 
-    operator void*() const { return (impl_ && impl_->isValid()) ? (void*)1 : (void*)0; }
+    operator void*() const { return (impl_ && isValid()) ? (void*)1 : (void*)0; }
 
     bool operator<(const Publisher& rhs) const
     {
@@ -172,6 +176,8 @@ namespace miniros
 
     void publishImpl(const std::function<SerializedMessage(void)>& serfunc, SerializedMessage& m) const;
     void incrementSequence() const;
+
+    std::shared_ptr<TopicManager> getTopicManager() const;
 
     class MINIROS_DECL Impl
     {

--- a/include/miniros/transport/service_manager.h
+++ b/include/miniros/transport/service_manager.h
@@ -116,7 +116,7 @@ public:
 
   bool advertiseService(const AdvertiseServiceOptions& ops);
 
-  void start();
+  void start(PollManagerPtr pm, ConnectionManagerPtr cm, XMLRPCManagerPtr rpcm);
   void shutdown();
 private:
 

--- a/include/miniros/transport/timer_manager.h
+++ b/include/miniros/transport/timer_manager.h
@@ -522,7 +522,7 @@ void TimerManager<T, D, E>::threadFunc()
         {
           current = T::now();
 
-          //ROS_DEBUG("Scheduling timer callback for timer [%d] of period [%f], [%f] off expected", info->handle, info->period.toSec(), (current - info->next_expected).toSec());
+          ROSCPP_LOG_DEBUG("Scheduling timer callback for timer [%d] of period [%f], [%f] off expected", info->handle, info->period.toSec(), (current - info->next_expected).toSec());
           CallbackInterfacePtr cb(std::make_shared<TimerQueueCallback>(this, info, info->last_expected, info->last_real, info->next_expected, info->last_expired, current));
           info->callback_queue->addCallback(cb, (uint64_t)info.get());
 

--- a/include/miniros/transport/topic_manager.h
+++ b/include/miniros/transport/topic_manager.h
@@ -65,7 +65,7 @@ public:
   TopicManager();
   ~TopicManager();
 
-  void start();
+  void start(PollManagerPtr pm, ConnectionManagerPtr cm, XMLRPCManagerPtr rpcm);
   void shutdown();
 
   bool subscribe(const SubscribeOptions& ops);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,11 +95,9 @@ set(ENCRYPT_LIBRARIES "")
 if(MINIROS_ROSBAG_USE_GPGME_ENCRYPTION)
   find_package(Gpgme REQUIRED)
 
-  if (GPGME_FOUND)
-    list(APPEND ENCRYPT_SOURCE "rosbag_storage/gpgme_utils.cpp")
-    list(APPEND rosbag_INCLUDE ${GPGME_INCLUDES})
-    list(APPEND ENCRYPT_LIBRARIES gpgme)
-  endif()
+  list(APPEND ENCRYPT_SOURCE "rosbag_storage/gpgme_utils.cpp")
+  list(APPEND rosbag_INCLUDE ${GPGME_INCLUDES})
+  list(APPEND ENCRYPT_LIBRARIES gpgme)
 endif()
 
 # AES encryption plugin
@@ -176,7 +174,12 @@ endif ()
 find_package(Threads REQUIRED)
 
 add_library(miniros_time STATIC ${rostime_SRC})
-target_include_directories(miniros_time PUBLIC ${MINIROS_INCLUDE_DIRS})
+target_include_directories(miniros_time
+  PUBLIC
+    $<BUILD_INTERFACE:${MINIROS_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
+
 set_property(TARGET miniros_time PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_library(miniros::time ALIAS miniros_time)
 
@@ -189,7 +192,9 @@ endif()
 
 set_property(TARGET roscxx PROPERTY CXX_STANDARD 17)
 
-target_link_libraries(roscxx PRIVATE xmlrpcpp rt stdc++fs miniros::time ${console_bridge_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(roscxx PRIVATE xmlrpcpp rt stdc++fs ${console_bridge_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+
+target_link_libraries(roscxx PUBLIC miniros::time)
 
 target_compile_definitions(roscxx PRIVATE rostime_EXPORTS miniros_EXPORTS)
 
@@ -256,4 +261,4 @@ if (MINIROS_BUILD_ROSBAG_APPS)
 endif()
 
 set(MINIROS_LIBRARY roscxx PARENT_SCOPE)
-set(MINIROS_EXPORT roscxx bag_storage ${rosbag_LIBS} PARENT_SCOPE)
+set(MINIROS_EXPORT roscxx bag_storage miniros_time ${rosbag_LIBS} PARENT_SCOPE)

--- a/src/transport/publication.cpp
+++ b/src/transport/publication.cpp
@@ -381,11 +381,8 @@ uint32_t Publication::getNumSubscribers()
 void Publication::getPublishTypes(bool& serialize, bool& nocopy, const std::type_info& ti)
 {
   std::scoped_lock<std::mutex> lock(subscriber_links_mutex_);
-  V_SubscriberLink::const_iterator it = subscriber_links_.begin();
-  V_SubscriberLink::const_iterator end = subscriber_links_.end();
-  for (; it != end; ++it)
+  for (const SubscriberLinkPtr& sub: subscriber_links_)
   {
-    const SubscriberLinkPtr& sub = *it;
     bool s = false;
     bool n = false;
     sub->getPublishTypes(s, n, ti);
@@ -410,11 +407,8 @@ void Publication::publish(SerializedMessage& m)
   if (m.message)
   {
     std::scoped_lock<std::mutex> lock(subscriber_links_mutex_);
-    V_SubscriberLink::const_iterator it = subscriber_links_.begin();
-    V_SubscriberLink::const_iterator end = subscriber_links_.end();
-    for (; it != end; ++it)
+    for (const SubscriberLinkPtr& sub: subscriber_links_)
     {
-      const SubscriberLinkPtr& sub = *it;
       if (sub->isIntraprocess())
       {
         sub->enqueueMessage(m, false, true);

--- a/src/transport/service_manager.cpp
+++ b/src/transport/service_manager.cpp
@@ -69,14 +69,13 @@ ServiceManager::~ServiceManager()
   shutdown();
 }
 
-void ServiceManager::start()
+void ServiceManager::start(PollManagerPtr pm, ConnectionManagerPtr cm, XMLRPCManagerPtr rpcm)
 {
   shutting_down_ = false;
 
-  poll_manager_ = PollManager::instance();
-  connection_manager_ = ConnectionManager::instance();
-  xmlrpc_manager_ = XMLRPCManager::instance();
-
+  poll_manager_ = pm;
+  connection_manager_ = cm;
+  xmlrpc_manager_ = rpcm;
 }
 
 void ServiceManager::shutdown()

--- a/src/transport/topic_manager.cpp
+++ b/src/transport/topic_manager.cpp
@@ -82,14 +82,14 @@ TopicManager::~TopicManager()
   shutdown();
 }
 
-void TopicManager::start()
+void TopicManager::start(PollManagerPtr pm, ConnectionManagerPtr cm, XMLRPCManagerPtr rpcm)
 {
   std::scoped_lock<std::mutex> shutdown_lock(shutting_down_mutex_);
   shutting_down_ = false;
 
-  poll_manager_ = PollManager::instance();
-  connection_manager_ = ConnectionManager::instance();
-  xmlrpc_manager_ = XMLRPCManager::instance();
+  poll_manager_ = pm;
+  connection_manager_ = cm;
+  xmlrpc_manager_ = rpcm;
 
   xmlrpc_manager_->bind("publisherUpdate",
     [this](XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result)

--- a/test/rostime/test_duration.cpp
+++ b/test/rostime/test_duration.cpp
@@ -80,8 +80,8 @@ TEST(Duration, castFromInt64Exceptions)
     // The next casts all incorrect.
     EXPECT_THROW(d1.fromSec(2147483648000000000), std::runtime_error);
     EXPECT_THROW(d2.fromSec(4294967296000000000), std::runtime_error);
-    EXPECT_THROW(d3.fromSec(-2147483648000000001), std::runtime_error);
-    EXPECT_THROW(d4.fromSec(-6442450943000000000), std::runtime_error);
+    EXPECT_THROW(d3.fromSec(-2.147483648E+18), std::runtime_error);
+    EXPECT_THROW(d4.fromSec(-6442450943000000512), std::runtime_error);
 }
 
 TEST(Duration, arithmeticExceptions)


### PR DESCRIPTION
Replace some singleton references by passing proper instances.

This is a small part of a bigger effort of eliminating very big global state of roscxx client.