### PR TITLE
Fixing race problems on shutdown

### DIFF
--- a/include/miniros/errors.h
+++ b/include/miniros/errors.h
@@ -27,6 +27,13 @@ struct MINIROS_DECL Error {
     ParameterNotFound,
     /// URI is invalid.
     InvalidURI,
+    /// Some internal error.
+    /// This is some serious assert-level problem.
+    InternalError,
+    /// Operation was interrupted by a shutdown request.
+    ShutdownInterrupt,
+    /// Incorrect or unexpected response.
+    InvalidResponse,
   };
 
   Error(Error_t c) : code(c)

--- a/include/miniros/internal/forwards.h
+++ b/include/miniros/internal/forwards.h
@@ -32,7 +32,6 @@
 #include <vector>
 #include <map>
 #include <set>
-#include <list>
 
 #include <memory>
 #include <functional>
@@ -70,18 +69,14 @@ typedef std::vector<SubscriberLinkPtr> V_SubscriberLink;
 class Subscription;
 typedef std::shared_ptr<Subscription> SubscriptionPtr;
 typedef std::weak_ptr<Subscription> SubscriptionWPtr;
-typedef std::list<SubscriptionPtr> L_Subscription;
-typedef std::set<SubscriptionPtr> S_Subscription;
 class PublisherLink;
 typedef std::shared_ptr<PublisherLink> PublisherLinkPtr;
 typedef std::vector<PublisherLinkPtr> V_PublisherLink;
 class ServicePublication;
 typedef std::shared_ptr<ServicePublication> ServicePublicationPtr;
-typedef std::list<ServicePublicationPtr> L_ServicePublication;
 typedef std::vector<ServicePublicationPtr> V_ServicePublication;
 class ServiceServerLink;
 typedef std::shared_ptr<ServiceServerLink> ServiceServerLinkPtr;
-typedef std::list<ServiceServerLinkPtr> L_ServiceServerLink;
 class Transport;
 typedef std::shared_ptr<Transport> TransportPtr;
 class NodeHandle;

--- a/include/miniros/master_link.h
+++ b/include/miniros/master_link.h
@@ -31,6 +31,7 @@
 #include "internal/forwards.h"
 
 #include "miniros/macros.h"
+#include "miniros/errors.h"
 
 namespace XmlRpc {
 class XmlRpcValue;
@@ -64,19 +65,19 @@ struct MINIROS_DECL TopicInfo {
  *  - registration of subscribers and publishers
  *  - interaction with rosparam part.
  */
-class MINIROS_DECL MasterLink {
+class MasterLink {
 public:
-  MasterLink(const std::shared_ptr<RPCManager>& rpcManager);
+  MINIROS_DECL MasterLink(const std::shared_ptr<RPCManager>& rpcManager);
 
-  ~MasterLink();
+  MINIROS_DECL ~MasterLink();
 
   using RpcValue = XmlRpc::XmlRpcValue;
 
   /// Init connection to rosmaster.
-  void initLink(const M_string& remappings);
+  MINIROS_DECL Error initLink(const M_string& remappings);
 
   /// Init rosparam part.
-  void initParam(const M_string& remappings);
+  MINIROS_DECL Error initParam(const M_string& remappings);
 
   /** @brief Execute an XMLRPC call on the master
    *
@@ -88,7 +89,7 @@ public:
    *
    * @return true if call succeeds, false otherwise.
    */
-  MINIROS_DECL bool execute(const std::string& method, const RpcValue& request,
+  MINIROS_DECL Error execute(const std::string& method, const RpcValue& request,
     RpcValue& response, RpcValue& payload, bool wait_for_master) const;
 
   /** @brief Get the hostname where the master runs.

--- a/include/miniros/transport/rosout_appender.h
+++ b/include/miniros/transport/rosout_appender.h
@@ -50,17 +50,16 @@ MINIROS_DECLARE_MESSAGE(Log)
 namespace miniros
 {
 
-class Publication;
-typedef std::shared_ptr<Publication> PublicationPtr;
-typedef std::weak_ptr<Publication> PublicationWPtr;
-
 class MasterLink;
-typedef std::shared_ptr<MasterLink> MasterLinkPtr;
+using MasterLinkPtr = std::shared_ptr<MasterLink>;
+
+class TopicManager;
+using TopicManagerPtr = std::shared_ptr<TopicManager>;
 
 class MINIROS_DECL ROSOutAppender : public console::LogAppender
 {
 public:
-  explicit ROSOutAppender(const MasterLinkPtr& master);
+  explicit ROSOutAppender(const TopicManagerPtr& tm);
   ~ROSOutAppender() override;
 
   const std::string& getLastError() const;
@@ -80,7 +79,7 @@ protected:
   bool disable_topics_;
 
   std::thread publish_thread_;
-  MasterLinkPtr master_;
+  TopicManagerPtr topic_manager_;
 };
 
 } // namespace miniros

--- a/include/miniros/transport/service_manager.h
+++ b/include/miniros/transport/service_manager.h
@@ -25,15 +25,17 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ROSCPP_SERVICE_MANAGER_H
-#define ROSCPP_SERVICE_MANAGER_H
+#ifndef MINIROS_SERVICE_MANAGER_H
+#define MINIROS_SERVICE_MANAGER_H
+
+#include <list>
+#include <mutex>
 
 #include "miniros/internal/forwards.h"
 #include "miniros/common.h"
 #include "advertise_service_options.h"
 #include "service_client_options.h"
 
-#include <mutex>
 
 namespace miniros
 {
@@ -130,10 +132,10 @@ private:
 
   bool isShuttingDown() { return shutting_down_; }
 
-  L_ServicePublication service_publications_;
+  std::list<ServicePublicationPtr> service_publications_;
   std::mutex service_publications_mutex_;
 
-  L_ServiceServerLink service_server_links_;
+  std::list<ServiceServerLinkPtr> service_server_links_;
   std::mutex service_server_links_mutex_;
 
   volatile bool shutting_down_;
@@ -147,4 +149,4 @@ private:
 
 } // namespace miniros
 
-#endif // ROSCPP_SERVICE_MANAGER_H
+#endif // MINIROS_SERVICE_MANAGER_H

--- a/include/miniros/transport/statistics.h
+++ b/include/miniros/transport/statistics.h
@@ -28,6 +28,7 @@
 #ifndef ROSCPP_STATISTICS_H
 #define ROSCPP_STATISTICS_H
 
+#include <list>
 #include <map>
 
 #include "miniros/internal/forwards.h"

--- a/include/miniros/transport/topic_manager.h
+++ b/include/miniros/transport/topic_manager.h
@@ -25,8 +25,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ROSCPP_TOPIC_MANAGER_H
-#define ROSCPP_TOPIC_MANAGER_H
+#ifndef MINIROS_TOPIC_MANAGER_H
+#define MINIROS_TOPIC_MANAGER_H
+
+#include <list>
 
 #include "miniros/internal/forwards.h"
 #include "miniros/common.h"
@@ -217,7 +219,7 @@ private:
   bool isShuttingDown() { return shutting_down_; }
 
   std::mutex subs_mutex_;
-  L_Subscription subscriptions_;
+  std::list<SubscriptionPtr> subscriptions_;
 
   std::recursive_mutex advertised_topics_mutex_;
   V_Publication advertised_topics_;
@@ -239,4 +241,4 @@ private:
 
 } // namespace miniros
 
-#endif // ROSCPP_TOPIC_MANAGER_H
+#endif // MINIROS_TOPIC_MANAGER_H

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -39,6 +39,7 @@
 #include "miniros/platform.h"
 #include "miniros/rostime.h"
 
+#include <atomic>
 #include <cstdio>
 #include <cstdarg>
 #include <cstring>
@@ -198,7 +199,7 @@ namespace console
 {
 
 bool g_initialized = false;
-bool g_shutting_down = false;
+std::atomic_bool g_shutting_down = false;
 std::mutex g_init_mutex;
 
 #ifdef ROSCONSOLE_BACKEND_LOG4CXX
@@ -710,7 +711,7 @@ std::string formatToString(const char* fmt, ...)
 static std::mutex g_print_mutex;
 static std::shared_ptr<char[]> g_print_buffer(new char[INITIAL_BUFFER_SIZE]);
 static size_t g_print_buffer_size = INITIAL_BUFFER_SIZE;
-static std::thread::id g_printing_thread_id;
+static std::atomic<std::thread::id> g_printing_thread_id;
 
 void print(FilterBase* filter, void* logger_handle, Level level,
     const char* file, int line, const char* function, const char* fmt, ...)

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -24,6 +24,12 @@ const char* Error::toString() const {
       return "Parameter not found";
    case Error::InvalidURI:
      return "Invalid URI";
+   case Error::InternalError:
+     return "Internal error";
+   case Error::ShutdownInterrupt:
+     return "Interrupted by shutdown request";
+   case Error::InvalidResponse:
+     return "Invalid response";
   }
   return "Unknown error";
 }

--- a/src/rostime/time.cpp
+++ b/src/rostime/time.cpp
@@ -37,15 +37,16 @@
   #endif
 #endif
 
-#include "miniros/rostime.h"
-#include "miniros/impl/time.h"
+#include <atomic>
 #include <cmath>
 #include <ctime>
 #include <iomanip>
 #include <limits>
 #include <stdexcept>
 #include <mutex>
-#include <cmath>
+
+#include "miniros/rostime.h"
+#include "miniros/impl/time.h"
 
 // time related includes for macOS
 #if defined(__APPLE__)
@@ -86,7 +87,7 @@ namespace miniros
 
   // This is declared here because it's set from the Time class but read from
   // the Duration class, and need not be exported to users of either.
-  static bool g_stopped(false);
+  static std::atomic_bool g_stopped(false);
 
   // I assume that this is declared here, instead of time.h, to keep users
   // of time.h from including boost/thread/mutex.hpp

--- a/src/transport/service_manager.cpp
+++ b/src/transport/service_manager.cpp
@@ -92,17 +92,16 @@ void ServiceManager::shutdown()
   {
     std::scoped_lock<std::mutex> ss_lock(service_publications_mutex_);
 
-    for (L_ServicePublication::iterator i = service_publications_.begin();
-         i != service_publications_.end(); ++i)
+    for (auto i = service_publications_.begin(); i != service_publications_.end(); ++i)
     {
       unregisterService((*i)->getName());
-      //MINIROS_DEBUG( "shutting down service %s", (*i)->getName().c_str());
+      MINIROS_DEBUG( "shutting down service %s", (*i)->getName().c_str());
       (*i)->drop();
     }
     service_publications_.clear();
   }
 
-  L_ServiceServerLink local_service_clients;
+  std::list<ServiceServerLinkPtr> local_service_clients;
   {
     std::scoped_lock<std::mutex> lock(service_server_links_mutex_);
     local_service_clients.swap(service_server_links_);
@@ -162,8 +161,7 @@ bool ServiceManager::unadvertiseService(const string &serv_name)
   {
     std::scoped_lock<std::mutex> lock(service_publications_mutex_);
 
-    for (L_ServicePublication::iterator i = service_publications_.begin();
-         i != service_publications_.end(); ++i)
+    for (auto i = service_publications_.begin(); i != service_publications_.end(); ++i)
     {
       if((*i)->getName() == serv_name && !(*i)->isDropped())
       {
@@ -286,7 +284,7 @@ void ServiceManager::removeServiceServerLink(const ServiceServerLinkPtr& client)
 
   std::scoped_lock<std::mutex> lock(service_server_links_mutex_);
 
-  L_ServiceServerLink::iterator it = std::find(service_server_links_.begin(), service_server_links_.end(), client);
+  auto it = std::find(service_server_links_.begin(), service_server_links_.end(), client);
   if (it != service_server_links_.end())
   {
     service_server_links_.erase(it);


### PR DESCRIPTION
Fixed some racing problems during ros::shutdown, especially when SIGINT was catched during ros::init. It does not fix  all valgrind/helgring issues though.