### PR TITLE
Fixing exported targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,8 @@ else()
     DESTINATION lib/cmake/${PROJECT_NAME}
   )
 
+  install(TARGETS miniroscore minibag RUNTIME DESTINATION bin)
+  
   install(TARGETS ${MINIROS_EXPORT} EXPORT ${PROJECT_NAME}
     LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib

--- a/package.xml
+++ b/package.xml
@@ -8,8 +8,9 @@
   <maintainer email="dmitry.n.kargin@gmail.com">Dmitry Kargin</maintainer>
   <license>BSD</license>
 
-  <url>Nope</url>
+  <url>https://github.com/dkargin/miniroscpp</url>
   <author>John Faust</author>
   <author>Dmitry Kargin</author>
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>cmake</buildtool_depend>
+
 </package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -309,7 +309,5 @@ set(MINIROS_LIBRARY roscxx PARENT_SCOPE)
 set(MINIROS_EXPORT
     roscxx
     bag_storage
-    miniroscore
-    minibag
     ${rosbag_INTERNAL_LIBS}
     PARENT_SCOPE)


### PR DESCRIPTION
Removed binaries "miniroscore" and "minibag" from exported targets but kept them in the install set. It resolves some of issues with yocto builds, when only development package of miniros is used, but it lacks binaries, since they've gone to 'binary' package