### PR TITLE
Topic update is sending proper list of URIs

### DIFF
--- a/src/roscore/master_handler.cpp
+++ b/src/roscore/master_handler.cpp
@@ -104,16 +104,14 @@ void MasterHandler::notifyTopicSubscribers(const std::string& topic, const std::
 
   // Note that list of URI can be different for different clients because of IP resolution and configuration of the network.
   std::vector<std::shared_ptr<NodeRef>> publishers = m_regManager->getTopicPublishers(topic);
-  RpcValue l = RpcValue::Array(publishers.size() + 1);
-
+  RpcValue l = RpcValue::Array(0);
   for (std::shared_ptr<NodeRef> sub: subscribers) {
     if (sub) {
-      l[0] = sub->getApi();
-      l[1] = "";
+      int j = 0;
       for (int i = 0; i < publishers.size(); i++) {
         if (publishers[i]) {
           network::URL url = m_resolver.resolveAddressFor(publishers[i], sub);
-          l[i + 1] = url.str();
+          l[j++] = url.str();
         }
       }
       Error err = this->enqueueNodeCommand(sub, "publisherUpdate", topic, l);

--- a/src/transport/topic_manager.cpp
+++ b/src/transport/topic_manager.cpp
@@ -958,10 +958,12 @@ Error TopicManager::pubUpdateCallback(const XmlRpc::XmlRpcValue& params, XmlRpc:
   for (int idx = 0; idx < params[2].size(); idx++) {
     std::string pub = params[2][idx];
     pubs.push_back(pub);
-    ss << pub << ",";
+    if (idx != 0)
+      ss << ",";
+    ss << pub;
   }
 
-  MINIROS_INFO("pubUpdateCallback(%s) publishers={%s}", topic.c_str(), ss.str().c_str());
+  MINIROS_DEBUG("pubUpdateCallback(%s) publishers={%s}", topic.c_str(), ss.str().c_str());
 
   if (pubUpdate(topic, pubs)) {
     result = xmlrpc::responseInt(1, "", 0);


### PR DESCRIPTION
Removed redundant API links in `publisherUpdate` notification from master