### PR TITLE
Fixed HTTP headers in updatePublisher command from master

### DIFF
--- a/src/roscore/master_handler.cpp
+++ b/src/roscore/master_handler.cpp
@@ -42,7 +42,8 @@ Error MasterHandler::enqueueNodeCommand(const std::shared_ptr<NodeRef>& nr, cons
   return Error::Ok;
 }
 
-Error MasterHandler::sendToNode(const std::shared_ptr<NodeRef>& nr, const char* method, const RpcValue& arg1, const RpcValue& arg2)
+Error MasterHandler::sendToNode(const std::shared_ptr<NodeRef>& nr, const char* method,
+  const RpcValue& arg1, const RpcValue& arg2)
 {
   if (!nr)
     return Error::InvalidValue;
@@ -52,17 +53,16 @@ Error MasterHandler::sendToNode(const std::shared_ptr<NodeRef>& nr, const char* 
   args[1] = arg1;
   args[2] = arg2;
 
-  uint32_t peer_port = 0;
-  std::string peer_host;
+  network::URL url;
   std::string nodeApi = nr->getApi();
-  if (!miniros::network::splitURI(nodeApi, peer_host, peer_port)) {
+  if (!url.fromString(nodeApi, false)) {
     MINIROS_ERROR_NAMED("handler", "Failed to splitURI of node \"%s\"", nodeApi.c_str());
     return Error::InvalidURI;
   }
 
   // It is expected that client is in idle state, so we can send request immediately without waiting for a response for
   // some previous request.
-  XmlRpc::XmlRpcClient* client = m_rpcManager->getXMLRPCClient(peer_host, peer_port, nodeApi);
+  XmlRpc::XmlRpcClient* client = m_rpcManager->getXMLRPCClient(url.host, url.port, url.path);
   if (!client) {
     MINIROS_ERROR_NAMED("handler", "Failed to create client to notify node \"%s\"", nodeApi.c_str());
     return Error::SystemError;

--- a/src/roscore/master_handler.h
+++ b/src/roscore/master_handler.h
@@ -38,7 +38,8 @@ public:
   MasterHandler(RPCManagerPtr rpcManager, RegistrationManager* regManager);
 
   /// Sends immediate command/update to a node.
-  Error sendToNode(const std::shared_ptr<NodeRef>& nr, const char* method, const RpcValue& arg1, const RpcValue& arg2 = {});
+  Error sendToNode(const std::shared_ptr<NodeRef>& nr, const char* method,
+    const RpcValue& arg1, const RpcValue& arg2 = {});
 
   /// Enqueues command to a node. It will be executed later in `update()` method.
   Error enqueueNodeCommand(const std::shared_ptr<NodeRef>& nr, const char* method, const RpcValue& arg1, const RpcValue& arg2 = {});
@@ -87,8 +88,12 @@ public:
 
   struct AsyncCommand {
     std::shared_ptr<NodeRef> node;
+
+    /// Name of XMLRPC command.
     std::string command;
+    /// First argument.
     RpcValue arg1;
+    /// Second argument.
     RpcValue arg2;
   };
 


### PR DESCRIPTION
Fixes an error with regular ros1 subscribers not getting proper "updatePublisher" XMLRPC notification about updated publishers.