### PR TITLE
Better parsing of topic list in minibag record

### DIFF
--- a/include/miniros/names.h
+++ b/include/miniros/names.h
@@ -156,6 +156,18 @@ protected:
   std::vector<std::string_view> m_ns;
 };
 
+/// Read list of topics from file.
+/// It is used by `minibag record` command.
+/// @param file - path to a file with a list of topics.
+/// @param topics - output array with topics.
+MINIROS_DECL bool readTopicList(const std::string& file, std::vector<std::string>& topics);
+
+/// Read topic list from a string.
+/// @param data - a buffer with topic list
+/// @param topics - output array with topics.
+MINIROS_DECL bool readTopicListStr(const std::string& data, std::vector<std::string>& topics);
+
+
 } // namespace names
 
 } // namespace miniros

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,12 +44,13 @@ SET(rostime_SRC
 
 set(cpp_common_SRC
     debug.cpp
+    errors.cpp
     header.cpp
     console.cpp
     common.cpp
-    errors.cpp
     console_print.cpp
     file_log.cpp
+    names.cpp
     serialization.cpp)
 
 set(rosbag_SRC "")
@@ -165,7 +166,6 @@ set(transport_SRC
     transport/master_link.cpp
     transport/message_deserializer.cpp
 
-    transport/names.cpp
     transport/network.cpp
     transport/net_address.cpp
     transport/node_handle.cpp

--- a/src/rosbag/main.cpp
+++ b/src/rosbag/main.cpp
@@ -397,16 +397,8 @@ minibag::RecorderOptions parseRecordOptions(int argc, char** argv) {
     if (vm.count("topic-list")) {
       std::vector<std::string> listFiles = vm["topic-list"].as< std::vector<std::string> >();
       for (const std::string& file: listFiles) {
-        std::ifstream in(file.c_str());
-        if (!in) {
+        if (!miniros::names::readTopicList(file, topics)) {
           std::cerr << "Failed to open file with topic list \"" << file.c_str() << "\"" << std::endl;
-          continue;
-        }
-        std::string line;
-        while (std::getline(in, line)) {
-          if (line.empty())
-            continue;
-          topics.push_back(line);
         }
       }
     }

--- a/test/roscpp/basic/test_names.cpp
+++ b/test/roscpp/basic/test_names.cpp
@@ -137,6 +137,26 @@ TEST(Names, testExtraction)
   EXPECT_STREQ(rightA.c_str(), srcPath.c_str());
 }
 
+TEST(Names, testGoodTopicList)
+{
+  const std::string rawList = R"(
+# Topics from first sensor
+/imu
+/temp
+# Topics from the second sensor
+/robot2/imu
+/robot2/mag
+/robot2/odom # Comment line 2
+
+# Only a single topic is parsed per line. Second topic in line is discarded.
+/topic2 /topic3
+)";
+  std::vector<std::string> topics;
+  names::readTopicListStr(rawList, topics);
+  ASSERT_EQ(topics.size(), 6);
+  ASSERT_EQ(topics.back(), std::string("/topic2"));
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
1. Improved parser of topic list. Now it extracts one valid ROS name and supports comments.
2. Added tests for this parser.