### PR TITLE
[master] Fixed return values for service requests

### DIFF
--- a/src/roscore/master.cpp
+++ b/src/roscore/master.cpp
@@ -123,12 +123,13 @@ Master::RpcValue Master::lookupService(const std::string& caller_id, const std::
 
   RpcValue res = RpcValue::Array(3);
   if (uri.empty()) {
-    res[0] = -1;
+    res[0] = 0;
     res[1] = std::string("Failed to lookup service '" + service + "'");
+    res[2] = RpcValue();
   } else {
     res[0] = 1;
     res[1] = std::string("rosrpc URI: [") + uri + "]";
-    res[3] = uri;
+    res[2] = uri;
   }
   return res;
 }
@@ -277,18 +278,17 @@ Master::RpcValue Master::unregisterPublisher(
 {
   MINIROS_INFO("UNPUBLISHING caller_id=\"%s\" caller_api=%s topic=\"%s\"", caller_id.c_str(), caller_api.c_str(), topic.c_str());
 
-  RpcValue res = RpcValue::Array(3);
   RequesterInfo requesterInfo;
   if (!requesterInfo.assign(caller_id, connection->getfd())) {
     MINIROS_WARN("Failed to read network address of caller %s", caller_id.c_str());
   }
   requesterInfo.callerApi = caller_api;
 
-
-  int ret = m_handler.unregisterPublisher(requesterInfo, topic);
-  res[0] = 1;
-  res[1] = std::string("unregistered ") + caller_id + std::string("as provder of ") + topic;
-  res[2] = ret;
+  ReturnStruct st = m_handler.unregisterPublisher(requesterInfo, topic);
+  RpcValue res = RpcValue::Array(3);
+  res[0] = st.statusCode;
+  res[1] = st.statusMessage;
+  res[2] = st.value;
   return res;
 }
 
@@ -312,17 +312,17 @@ Master::RpcValue Master::registerSubscriber(const std::string& caller_id, const 
 Master::RpcValue Master::unregisterSubscriber(
   const std::string& caller_id, const std::string& topic, const std::string& caller_api, Connection* connection)
 {
-  RpcValue res = RpcValue::Array(3);
   RequesterInfo requesterInfo;
   if (!requesterInfo.assign(caller_id, connection->getfd())) {
     MINIROS_WARN("Failed to read network address of caller %s", caller_id.c_str());
   }
   requesterInfo.callerApi = caller_api;
 
-  int ret = m_handler.unregisterSubscriber(requesterInfo, topic);
-  res[0] = 1;
-  res[1] = std::string("unregistered ") + caller_id + std::string("as provder of ") + topic;
-  res[2] = ret;
+  ReturnStruct st = m_handler.unregisterSubscriber(requesterInfo, topic);
+  RpcValue res = RpcValue::Array(3);
+  res[0] = st.statusCode;
+  res[1] = st.statusMessage;
+  res[2] = st.value;
   return res;
 }
 

--- a/src/roscore/master_handler.cpp
+++ b/src/roscore/master_handler.cpp
@@ -141,7 +141,6 @@ std::string MasterHandler::lookupService(const RequesterInfo& requesterInfo, con
   std::string service_api = m_regManager->services.get_service_api(service);
   std::shared_ptr<NodeRef> node = m_regManager->getNodeByAPI(service_api);
   if (node && requesterInfo.clientAddress.valid()) {
-    // TODO: resolve service_api
     network::URL url = m_resolver.resolveAddressFor(node, requesterInfo.clientAddress, requesterInfo.localAddress);
     return url.str();
   }
@@ -202,13 +201,12 @@ ReturnStruct MasterHandler::registerSubscriber(const RequesterInfo& requesterInf
   return rtn;
 }
 
-int MasterHandler::unregisterSubscriber(const RequesterInfo& requesterInfo, const std::string& topic)
+ReturnStruct MasterHandler::unregisterSubscriber(const RequesterInfo& requesterInfo, const std::string& topic)
 {
   // Subscriber can be unregistered either by a direct call of actual subscriber,
   // or as a part of cleanup procedure from rosnode/rostopic utility. So we do not need to check whether
   // the topic actually belongs to specified caller_id.
-  m_regManager->unregister_subscriber(topic, requesterInfo.callerId, requesterInfo.callerApi);
-  return 1;
+  return m_regManager->unregister_subscriber(topic, requesterInfo.callerId, requesterInfo.callerApi);
 }
 
 ReturnStruct MasterHandler::registerPublisher(const RequesterInfo& requesterInfo, const std::string& topic,
@@ -218,7 +216,7 @@ ReturnStruct MasterHandler::registerPublisher(const RequesterInfo& requesterInfo
     topic.c_str(), requesterInfo.callerId.c_str(), requesterInfo.callerApi.c_str(), topic_type.c_str());
 
   if (topic.empty() || topic_type.empty()) {
-    ReturnStruct(-1, "Request error");
+    return ReturnStruct(-1, "Request error");
   }
 
   {
@@ -254,7 +252,7 @@ ReturnStruct MasterHandler::registerPublisher(const RequesterInfo& requesterInfo
   return rtn;
 }
 
-int MasterHandler::unregisterPublisher(const RequesterInfo& requesterInfo, const std::string& topic)
+ReturnStruct MasterHandler::unregisterPublisher(const RequesterInfo& requesterInfo, const std::string& topic)
 {
   MINIROS_INFO_NAMED("handler", "unregisterPublisher(\"%s\") caller_id=%s caller_api=%s",
     topic.c_str(), requesterInfo.callerId.c_str(), requesterInfo.callerApi.c_str());
@@ -268,7 +266,7 @@ int MasterHandler::unregisterPublisher(const RequesterInfo& requesterInfo, const
     notifyTopicSubscribers(topic, subscribers);
   }
 
-  return 1;
+  return ret;
 }
 
 std::string MasterHandler::lookupNode(const RequesterInfo& requesterInfo, const std::string& node_name) const

--- a/src/roscore/master_handler.h
+++ b/src/roscore/master_handler.h
@@ -56,11 +56,11 @@ public:
 
   ReturnStruct registerSubscriber(const RequesterInfo& requesterInfo, const std::string& topic, const std::string& topic_type);
 
-  int unregisterSubscriber(const RequesterInfo& requesterInfo, const std::string& topic);
+  ReturnStruct unregisterSubscriber(const RequesterInfo& requesterInfo, const std::string& topic);
 
   ReturnStruct registerPublisher(const RequesterInfo& requesterInfo, const std::string& topic, const std::string& topic_type);
 
-  int unregisterPublisher(const RequesterInfo& requesterInfo, const std::string& topic);
+  ReturnStruct unregisterPublisher(const RequesterInfo& requesterInfo, const std::string& topic);
 
   std::string lookupNode(const RequesterInfo& requesterInfo, const std::string& node_name) const;
 

--- a/src/roscore/registration_manager.cpp
+++ b/src/roscore/registration_manager.cpp
@@ -97,8 +97,10 @@ ReturnStruct RegistrationManager::unregisterObject(Registrations& r, const std::
     }
   }
 
-  if (node_ref->is_empty()) {
-    unregisterNode(caller_id);
+  if (node_ref) {
+    if (node_ref->is_empty()) {
+      unregisterNode(caller_id);
+    }
   }
   return ret;
 }

--- a/src/roscore/registrations.h
+++ b/src/roscore/registrations.h
@@ -24,7 +24,7 @@ struct ReturnStruct
     std::string statusMessage;
     XmlRpc::XmlRpcValue value;
 
-    ReturnStruct(int _statusCode = 1, std::string _statusMessage = "", XmlRpc::XmlRpcValue _value = {})
+    ReturnStruct(int _statusCode = 1, const std::string& _statusMessage = "", XmlRpc::XmlRpcValue _value = {})
     {
         statusCode = _statusCode;
         statusMessage = _statusMessage;


### PR DESCRIPTION
1. Fixed incorrect response to `lookupService` XMLRPC request. Now it properly returns 3 objects.
2. Fixed crash when unregistering topic when it was not properly registered before.