### PR TITLE
Minor fixes

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,3 +23,8 @@ target_include_directories(listener PRIVATE ${MINIROS_INCLUDE_GENERATED_DIRS})
 add_executable(log_demo log_demo.cpp)
 target_link_libraries(log_demo roscxx)
 target_include_directories(log_demo PRIVATE ${MINIROS_INCLUDE_GENERATED_DIRS})
+
+# A benchmark for sending messages.
+add_executable(bench_talker bench_talker.cpp)
+target_link_libraries(bench_talker roscxx)
+target_include_directories(bench_talker PRIVATE ${MINIROS_INCLUDE_GENERATED_DIRS})

--- a/examples/bench_talker.cpp
+++ b/examples/bench_talker.cpp
@@ -1,0 +1,110 @@
+//
+// Created by dkargin on 7/28/25.
+//
+
+/**
+ * This tutorial demonstrates simple receipt of messages over the ROS system.
+ * It is an adaptation of official ROS tutorial at http://wiki.ros.org/ROS/Tutorials/WritingPublisherSubscriber%28c%2B%2B%29
+ */
+#include <chrono>
+#include "miniros/ros.h"
+#include "miniros/xmlrpcpp/XmlRpcUtil.h"
+/// Messages for miniros have .hxx file extension to make them distinguishable from original ROS messages.
+#include "std_msgs/String.hxx"
+
+#include <sstream>
+
+int main(int argc, char **argv)
+{
+  //XmlRpc::setVerbosity(4);
+  auto timeStart = std::chrono::high_resolution_clock::now();
+  /**
+   * The miniros::init() function needs to see argc and argv so that it can perform
+   * any ROS arguments and name remapping that were provided at the command line.
+   * For programmatic remappings you can use a different version of init() which takes
+   * remappings directly, but for most command-line programs, passing argc and argv is
+   * the easiest way to do it.  The third argument to init() is the name of the node.
+   *
+   * You must call one of the versions of miniros::init() before using any other
+   * part of the ROS system.
+   */
+  miniros::init(argc, argv, "talker_benchmark");
+
+  /**
+   * NodeHandle is the main access point to communications with the ROS system.
+   * The first NodeHandle constructed will fully initialize this node, and the last
+   * NodeHandle destructed will close down the node.
+   */
+  miniros::NodeHandle n;
+
+  /**
+   * The advertise() function is how you tell ROS that you want to
+   * publish on a given topic name. This invokes a call to the ROS
+   * master node, which keeps a registry of who is publishing and who
+   * is subscribing. After this advertise() call is made, the master
+   * node will notify anyone who is trying to subscribe to this topic name,
+   * and they will in turn negotiate a peer-to-peer connection with this
+   * node.  advertise() returns a Publisher object which allows you to
+   * publish messages on that topic through a call to publish().  Once
+   * all copies of the returned Publisher object are destroyed, the topic
+   * will be automatically unadvertised.
+   *
+   * The second parameter to advertise() is the size of the message queue
+   * used for publishing messages.  If messages are published more quickly
+   * than we can send them, the number here specifies how many messages to
+   * buffer up before throwing some away.
+   */
+  miniros::Publisher chatter_pub = n.advertise<std_msgs::String>("chatter", 1000);
+
+  auto timeEnd = std::chrono::high_resolution_clock::now();
+  auto delta = std::chrono::duration_cast<std::chrono::milliseconds>(timeEnd - timeStart);
+  MINIROS_INFO("Node initialized in %dms", (int)delta.count());
+
+  int rate = n.param<int>("rate", 10);
+  if (rate < 1) {
+    MINIROS_ERROR("Rate %d is too low", rate);
+    return EXIT_FAILURE;
+  }
+
+  int max_messages = n.param<int>("max_messages", 100);
+
+  miniros::Rate loop_rate(rate);
+  /**
+   * A count of how many messages we have sent. This is used to create
+   * a unique string for each message.
+   */
+  int count = 0;
+  while (miniros::ok())
+  {
+    /**
+     * This is a message object. You stuff it with data, and then publish it.
+     */
+    std_msgs::String msg;
+
+    std::stringstream ss;
+    ss << "hello world " << count;
+    msg.data = ss.str();
+
+    MINIROS_INFO("%s", msg.data.c_str());
+
+    n.setParam("i1", count);
+    n.setParam("i2", count);
+
+    /**
+     * The publish() function is how you send messages. The parameter
+     * is the message object. The type of this object must agree with the type
+     * given as a template parameter to the advertise<>() call, as was done
+     * in the constructor above.
+     */
+    chatter_pub.publish(msg);
+
+    miniros::spinOnce();
+
+    loop_rate.sleep();
+    ++count;
+    if (max_messages > 0 && count >= max_messages)
+      break;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/include/miniros/master_link.h
+++ b/include/miniros/master_link.h
@@ -67,17 +67,20 @@ struct MINIROS_DECL TopicInfo {
  */
 class MasterLink {
 public:
-  MINIROS_DECL MasterLink(const std::shared_ptr<RPCManager>& rpcManager);
+  MINIROS_DECL MasterLink();
 
   MINIROS_DECL ~MasterLink();
 
   using RpcValue = XmlRpc::XmlRpcValue;
 
   /// Init connection to rosmaster.
-  MINIROS_DECL Error initLink(const M_string& remappings);
+  MINIROS_DECL Error initLink(const M_string& remappings, const std::shared_ptr<RPCManager>& rpcManager);
 
   /// Init rosparam part.
   MINIROS_DECL Error initParam(const M_string& remappings);
+
+  /// Stop serving any request.
+  MINIROS_DECL void disconnect();
 
   /** @brief Execute an XMLRPC call on the master
    *

--- a/include/miniros/xmlrpcpp/XmlRpcClient.h
+++ b/include/miniros/xmlrpcpp/XmlRpcClient.h
@@ -9,6 +9,8 @@
 #endif
 
 
+#include <atomic>
+
 #ifndef MAKEDEPEND
 # include <string>
 #endif
@@ -92,7 +94,8 @@ namespace XmlRpc {
 
     // Possible IO states for the connection
     enum ClientConnectionState { NO_CONNECTION, CONNECTING, WRITE_REQUEST, READ_HEADER, READ_RESPONSE, IDLE };
-    ClientConnectionState _connectionState;
+
+    std::atomic<ClientConnectionState> _connectionState;
 
     static const char * connectionStateStr(ClientConnectionState state);
 

--- a/src/transport/callback_queue.cpp
+++ b/src/transport/callback_queue.cpp
@@ -116,17 +116,12 @@ void CallbackQueue::addCallback(const CallbackInterfacePtr& callback, uint64_t r
     }
   }
 
-  {
-    std::scoped_lock<std::mutex> lock(mutex_);
+  std::scoped_lock<std::mutex> lock(mutex_);
 
-    if (!enabled_)
-    {
-      return;
-    }
+  if (!enabled_)
+    return;
 
-    callbacks_.push_back(info);
-  }
-
+  callbacks_.push_back(info);
   condition_.notify_one();
 }
 

--- a/src/transport/init.cpp
+++ b/src/transport/init.cpp
@@ -500,8 +500,8 @@ void init(const M_string& remappings, const std::string& name, uint32_t options)
     check_ipv6_environment();
     network::init(remappings);
     auto rpcManager = RPCManager::instance();
-    g_master_link.reset(new MasterLink(rpcManager));
-    g_master_link->initLink(remappings);
+    g_master_link.reset(new MasterLink());
+    g_master_link->initLink(remappings, rpcManager);
     // names:: namespace is initialized by this_node
     this_node::init(name, remappings, options);
     file_log::init(remappings);

--- a/src/xmlrpc/XmlRpcUtil.cpp
+++ b/src/xmlrpc/XmlRpcUtil.cpp
@@ -1,6 +1,8 @@
 
 #include "xmlrpcpp/XmlRpcUtil.h"
 
+#include <mutex>
+
 #ifndef MAKEDEPEND
 # include <ctype.h>
 # include <iostream>
@@ -34,9 +36,13 @@ public:
 #ifdef USE_WINDOWS_DEBUG
     if (level <= _verbosity) { OutputDebugString(msg); OutputDebugString("\n"); }
 #else
-    if (level <= _verbosity) std::cout << msg << std::endl; 
+    if (level <= _verbosity) {
+      std::scoped_lock lock(_guard);
+      std::cout << msg << std::endl;
+    }
 #endif  
   }
+  std::mutex _guard;
 
 } defaultLogHandler;
 


### PR DESCRIPTION
Fixing potential racing conditions and warnings from valgrind/helgrind:
1. Potential racing condition in XmlRpcUtil::log. It was invoked from multiple threads and helgrind put a lot of warnings about writing to std::cout without any guards.
2. State of XmlRpcClient is atomic now
3. Resolved warnings about missing lock before invoking condition_variable.notify(). Helgrind prefers that CV is in the same locked area during `notify` call as in `wait` call.