### PR TITLE
Fixed blinking crash in test_transport_tcp

### DIFF
--- a/.github/workflows/cmake-multiplatform.yml
+++ b/.github/workflows/cmake-multiplatform.yml
@@ -73,4 +73,4 @@ jobs:
         ROS_MASTER_URI: http://localhost:11311
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ROS_MASTER_URI=http://localhost:11311 ctest --test-dir test -C ${{env.BUILD_TYPE}}
+      run: ROS_MASTER_URI=http://localhost:11311 ctest --output-on-failure --test-dir test -C ${{env.BUILD_TYPE}}

--- a/include/miniros/transport/transport_tcp.h
+++ b/include/miniros/transport/transport_tcp.h
@@ -35,6 +35,7 @@
 #ifndef MINIROS_TRANSPORT_TCP_H
 #define MINIROS_TRANSPORT_TCP_H
 
+#include <atomic>
 #include <mutex>
 
 #include <miniros/types.h>
@@ -68,7 +69,7 @@ public:
   };
 
   TransportTCP(PollSet* poll_set, int flags = 0);
-  virtual ~TransportTCP();
+  ~TransportTCP() override;
 
   /**
    * \brief Connect to a remote host.
@@ -108,21 +109,21 @@ public:
   int getConnectedPort() { return connected_port_; }
 
   // overrides from Transport
-  virtual int32_t read(uint8_t* buffer, uint32_t size);
-  virtual int32_t write(uint8_t* buffer, uint32_t size);
+  int32_t read(uint8_t* buffer, uint32_t size) override;
+  int32_t write(uint8_t* buffer, uint32_t size) override;
 
-  virtual void enableWrite();
-  virtual void disableWrite();
-  virtual void enableRead();
-  virtual void disableRead();
+  void enableWrite() override;
+  void disableWrite() override;
+  void enableRead() override;
+  void disableRead() override;
 
-  virtual void close();
+  void close() override;
 
-  virtual std::string getTransportInfo();
+  std::string getTransportInfo() override;
 
-  virtual void parseHeader(const Header& header);
+  void parseHeader(const Header& header) override;
 
-  virtual const char* getType() { return "TCPROS"; }
+  const char* getType() override { return "TCPROS"; }
 
 private:
   /**
@@ -145,8 +146,8 @@ private:
   bool closed_;
   std::recursive_mutex close_mutex_;
 
-  bool expecting_read_;
-  bool expecting_write_;
+  std::atomic<bool> expecting_read_;
+  std::atomic<bool> expecting_write_;
 
   bool is_server_;
   sockaddr_storage server_address_;

--- a/test/roscpp/basic/test_transport_tcp.cpp
+++ b/test/roscpp/basic/test_transport_tcp.cpp
@@ -133,6 +133,7 @@ TEST_F(Synchronous, readWhileWriting)
   {
     const uint32_t buf_size = 1024*1024;
     std::shared_ptr<uint8_t[]> read_buf(new uint8_t[buf_size]);
+    memset(read_buf.get(), 0, buf_size);
 
     std::stringstream ss;
     for (int i = 0; i < 100000; ++i)


### PR DESCRIPTION
Test was allocating some big character buffer and was using ASSERT_STREQ for comparison with result buffer. Since read_buf was not zero-terminated, comparison could lead to segfault.

Fixes #66