### PR TITLE
Added an option --ignore-topics to minibag play

### DIFF
--- a/include/minibag/player.h
+++ b/include/minibag/player.h
@@ -98,6 +98,10 @@ struct PlayerOptions
     std::vector<std::string> bags;
     std::vector<std::string> topics;
     std::vector<std::string> pause_topics;
+
+    /// A set of topics to be ignored during playback.
+    /// It is in case of playing all topics from bag.
+    std::set<std::string> ignore_topics;
 };
 
 

--- a/src/rosbag/main.cpp
+++ b/src/rosbag/main.cpp
@@ -53,6 +53,7 @@ minibag::PlayerOptions parsePlayOptions(int argc, char** argv) {
       ("wait-for-subscribers", "wait for at least one subscriber on each topic before publishing")
       ("rate-control-topic", po::value<std::string>(), "watch the given topic, and if the last publish was more than <rate-control-max-delay> ago, wait until the topic publishes again to continue playback")
       ("rate-control-max-delay", po::value<float>()->default_value(1.0f), "maximum time difference from <rate-control-topic> before pausing")
+      ("ignore-topics", po::value< std::vector<std::string> >()->multitoken(), "topics to be skipped if playing whole bag")
       ;
 
     po::positional_options_description p;
@@ -117,6 +118,13 @@ minibag::PlayerOptions parsePlayOptions(int argc, char** argv) {
       opts.keep_alive = true;
     if (vm.count("wait-for-subscribers"))
       opts.wait_for_subscribers = true;
+
+    if (vm.count("ignore-topics")) {
+      std::vector<std::string> ignore_topics = vm["ignore-topics"].as< std::vector<std::string> >();
+      for (const std::string& topic: ignore_topics) {
+        opts.ignore_topics.insert(topic);
+      }
+    }
 
     if (vm.count("topics"))
     {

--- a/src/rosbag/player.cpp
+++ b/src/rosbag/player.cpp
@@ -197,7 +197,8 @@ void Player::publish() {
     // Advertise all of our messages
     for (const ConnectionInfo* c : view.getConnections())
     {
-        advertise(c);
+        if (!options_.ignore_topics.count(c->topic))
+          advertise(c);
     }
 
     if (options_.rate_control_topic != "")
@@ -251,9 +252,10 @@ void Player::publish() {
                 const auto header_iter = c->header->find("callerid");
                 const auto callerid = (header_iter != c->header->end() ? header_iter->second : string(""));
 
-                latch_topics.emplace(callerid, c->topic);
-
-                advertise(c);
+                if (!options_.ignore_topics.count(c->topic)) {
+                  latch_topics.emplace(callerid, c->topic);
+                  advertise(c);
+                }
             }
         }
 
@@ -320,7 +322,8 @@ void Player::publish() {
             if (!node_handle_.ok())
                 break;
 
-            doPublish(m);
+            if (!options_.ignore_topics.count(m.getTopic()))
+              doPublish(m);
         }
 
         if (options_.keep_alive)


### PR DESCRIPTION
Added an option `--ignore-topics` to `minibag play` command. An example:

Example invocation:

```bash
minibag play --ignore-topics /imu /mag --bags /datasets/bags/flight1.bag /datasets/bags/flight2.bag
```