### PR TITLE
Catching crashes in tests

### DIFF
--- a/include/miniros/common.h
+++ b/include/miniros/common.h
@@ -52,6 +52,11 @@ MINIROS_DECL Error makeDirectory(const std::string& path);
 
 MINIROS_DECL Error changeCurrentDirectory(const std::string& path);
 
+/// Enable printing backtrace during crash.
+/// For internal usage only.
+MINIROS_DECL Error handleCrashes();
+
+
 }
 
 #endif

--- a/include/miniros/transport/transport_tcp.h
+++ b/include/miniros/transport/transport_tcp.h
@@ -143,7 +143,7 @@ private:
   void socketUpdate(int events);
 
   socket_fd_t sock_;
-  bool closed_;
+  std::atomic<bool> closed_;
   std::recursive_mutex close_mutex_;
 
   std::atomic<bool> expecting_read_;

--- a/test/roscpp/basic/test_callback_queue.cpp
+++ b/test/roscpp/basic/test_callback_queue.cpp
@@ -478,6 +478,8 @@ TEST(CallbackQueue, raceConditionCallback)
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+  miniros::handleCrashes();
+
   return RUN_ALL_TESTS();
 }
 

--- a/test/roscpp/basic/test_http.cpp
+++ b/test/roscpp/basic/test_http.cpp
@@ -210,5 +210,7 @@ TEST(net, parseResponse)
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+  miniros::handleCrashes();
+
   return RUN_ALL_TESTS();
 }

--- a/test/roscpp/basic/test_observer.cpp
+++ b/test/roscpp/basic/test_observer.cpp
@@ -87,6 +87,7 @@ TEST(Observers, DetachAll)
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+
   return RUN_ALL_TESTS();
 }
 

--- a/test/roscpp/basic/test_poll_set.cpp
+++ b/test/roscpp/basic/test_poll_set.cpp
@@ -533,6 +533,7 @@ TEST_F(Poller, signal)
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+  miniros::handleCrashes();
 
 #ifndef _WIN32
   signal(SIGPIPE, SIG_IGN);

--- a/test/roscpp/basic/test_subscription_queue.cpp
+++ b/test/roscpp/basic/test_subscription_queue.cpp
@@ -290,6 +290,7 @@ TEST(SubscriptionQueue, nonConcurrentOrdering)
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+  miniros::handleCrashes();
   miniros::init(argc, argv, "blah");
   return RUN_ALL_TESTS();
 }

--- a/test/roscpp/basic/test_transport_tcp.cpp
+++ b/test/roscpp/basic/test_transport_tcp.cpp
@@ -475,6 +475,7 @@ TEST_F(Polled, disconnectReader)
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+  miniros::handleCrashes();
 
 #ifndef _WIN32
   signal(SIGPIPE, SIG_IGN);


### PR DESCRIPTION
CI was not providing any backtrace if test has crashed. Now it provides.

Added printing of backtrace in some tests.