### PR TITLE
Updated PollSet: now it can set event flags during addSocket call

### DIFF
--- a/include/miniros/transport/io.h
+++ b/include/miniros/transport/io.h
@@ -179,7 +179,7 @@ MINIROS_DECL int create_signal_pair(signal_fd_t signal_pair[2]);
 
 MINIROS_DECL int create_socket_watcher();
 MINIROS_DECL void close_socket_watcher(int fd);
-MINIROS_DECL void add_socket_to_watcher(int epfd, int fd);
+MINIROS_DECL void add_socket_to_watcher(int epfd, int fd, int events);
 MINIROS_DECL void del_socket_from_watcher(int epfd, int fd);
 MINIROS_DECL void set_events_on_socket(int epfd, int fd, int events);
 

--- a/include/miniros/transport/poll_set.h
+++ b/include/miniros/transport/poll_set.h
@@ -36,15 +36,11 @@
 #define MINIROS_POLL_SET_H
 
 #include <functional>
-#include <mutex>
 
 #include "miniros/common.h"
 
 namespace miniros
 {
-
-class Transport;
-typedef std::shared_ptr<Transport> TransportPtr;
 
 /**
  * \brief Manages a set of sockets being polled through the poll() function call.
@@ -58,17 +54,21 @@ public:
   PollSet();
   ~PollSet();
 
+  /// Object to be kept back during active callback.
+  typedef std::shared_ptr<void> TrackedObject;
+
   typedef std::function<void(int)> SocketUpdateFunc;
   /**
    * \brief Add a socket.
    *
    * addSocket() may be called from any thread.
    * \param sock The socket to add
+   * \param events selected events.
    * \param update_func The function to call when a socket has events
-   * \param transport The (optional) transport associated with this socket. Mainly
+   * \param object The (optional) object associated with this socket. Mainly
    * used to prevent the transport from being deleted while we're calling the update function
    */
-  bool addSocket(int sock, const SocketUpdateFunc& update_func, const TransportPtr& transport = TransportPtr());
+  bool addSocket(int sock, int events, const SocketUpdateFunc& update_func, const TrackedObject& object = TrackedObject());
   /**
    * \brief Delete a socket
    *

--- a/src/transport/io.cpp
+++ b/src/transport/io.cpp
@@ -125,13 +125,13 @@ void close_socket_watcher(int fd)
     ::close(fd);
 }
 
-void add_socket_to_watcher(int epfd, int fd)
+void add_socket_to_watcher(int epfd, int fd, int events)
 {
 #if defined(HAVE_EPOLL)
   struct epoll_event ev;
   bzero(&ev, sizeof(ev));
 
-  ev.events = 0;
+  ev.events = events;
   ev.data.fd = fd;
 
   if (::epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev)) {

--- a/src/transport/transport/transport_tcp.cpp
+++ b/src/transport/transport/transport_tcp.cpp
@@ -142,11 +142,13 @@ bool TransportTCP::initializeSocket()
   {
     MINIROS_DEBUG("Adding tcp socket [%d] to pollset", sock_);
     auto thisptr = std::static_pointer_cast<TransportTCP>(shared_from_this());
-    poll_set_->addSocket(sock_, [thisptr](int val){thisptr->socketUpdate(val);});
+    int events = 0;
 #if defined(POLLRDHUP) // POLLRDHUP is not part of POSIX!
     // This is needed to detect dead connections. #1704
-    poll_set_->addEvents(sock_, POLLRDHUP);
+    events = POLLRDHUP;
 #endif
+
+    poll_set_->addSocket(sock_, events, [thisptr](int val){thisptr->socketUpdate(val);});
   }
 
   if (!(flags_ & SYNCHRONOUS))

--- a/src/transport/transport/transport_udp.cpp
+++ b/src/transport/transport/transport_udp.cpp
@@ -299,7 +299,7 @@ bool TransportUDP::initializeSocket()
   if (poll_set_)
   {
     auto thisptr = std::static_pointer_cast<TransportUDP>(shared_from_this());
-    poll_set_->addSocket(sock_, [thisptr](int val){thisptr->socketUpdate(val);});
+    poll_set_->addSocket(sock_, 0, [thisptr](int val){thisptr->socketUpdate(val);});
   }
 
   return true;

--- a/test/roscpp/basic/test_poll_set.cpp
+++ b/test/roscpp/basic/test_poll_set.cpp
@@ -267,7 +267,7 @@ public:
 TEST_F(Poller, read)
 {
   SocketHelper sh(sockets_[0]);
-  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, [&sh](int events){sh.processEvents(events);}));
+  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, 0, [&sh](int events){sh.processEvents(events);}));
 
   char b = 0;
 
@@ -304,7 +304,7 @@ TEST_F(Poller, read)
 TEST_F(Poller, write)
 {
   SocketHelper sh(sockets_[0]);
-  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, [&sh](int events){sh.processEvents(events);}));
+  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, 0, [&sh](int events){sh.processEvents(events);}));
   ASSERT_TRUE(poll_set_.addEvents(sh.socket_, POLLOUT));
 
   poll_set_.update(1);
@@ -322,8 +322,8 @@ TEST_F(Poller, readAndWrite)
 {
   SocketHelper sh1(sockets_[0]);
   SocketHelper sh2(sockets_[1]);
-  ASSERT_TRUE(poll_set_.addSocket(sh1.socket_, [&sh1](int events){sh1.processEvents(events);}));
-  ASSERT_TRUE(poll_set_.addSocket(sh2.socket_, [&sh2](int events){sh2.processEvents(events);}));
+  ASSERT_TRUE(poll_set_.addSocket(sh1.socket_, 0, [&sh1](int events){sh1.processEvents(events);}));
+  ASSERT_TRUE(poll_set_.addSocket(sh2.socket_, 0, [&sh2](int events){sh2.processEvents(events);}));
 
   ASSERT_TRUE(poll_set_.addEvents(sh1.socket_, POLLIN));
   ASSERT_TRUE(poll_set_.addEvents(sh2.socket_, POLLIN));
@@ -359,8 +359,8 @@ TEST_F(Poller, readAndWrite)
 TEST_F(Poller, multiAddDel)
 {
   SocketHelper sh(sockets_[0]);
-  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, [&sh](int events){sh.processEvents(events);}));
-  ASSERT_FALSE(poll_set_.addSocket(sh.socket_, [&sh](int events){sh.processEvents(events);}));
+  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, 0, [&sh](int events){sh.processEvents(events);}));
+  ASSERT_FALSE(poll_set_.addSocket(sh.socket_, 0, [&sh](int events){sh.processEvents(events);}));
 
   ASSERT_TRUE(poll_set_.addEvents(sh.socket_, 0));
   ASSERT_FALSE(poll_set_.addEvents(sh.socket_ + 1, 0));
@@ -376,7 +376,7 @@ void addThread(PollSet* ps, SocketHelper* sh, Barrier* barrier)
 {
   barrier->wait();
 
-  ps->addSocket(sh->socket_, [sh](int events){sh->processEvents(events);});
+  ps->addSocket(sh->socket_, 0, [sh](int events){sh->processEvents(events);});
   ps->addEvents(sh->socket_, POLLIN);
   ps->addEvents(sh->socket_, POLLOUT);
 }
@@ -469,11 +469,11 @@ void addDelManyTimesThread(PollSet* ps, SocketHelper* sh1, SocketHelper* sh2, Ba
 
   for (int i = 0; i < count; ++i)
   {
-    ps->addSocket(sh1->socket_, [sh1](int events){sh1->processEvents(events);});
+    ps->addSocket(sh1->socket_, 0, [sh1](int events){sh1->processEvents(events);});
     ps->addEvents(sh1->socket_, POLLIN);
     ps->addEvents(sh1->socket_, POLLOUT);
 
-    ps->addSocket(sh2->socket_, [sh2](int events){sh2->processEvents(events);});
+    ps->addSocket(sh2->socket_, 0, [sh2](int events){sh2->processEvents(events);});
     ps->addEvents(sh2->socket_, POLLIN);
     ps->addEvents(sh2->socket_, POLLOUT);
 


### PR DESCRIPTION
`PollSet::addSocket` method can set initial event flags. It reduces some threading overhead while setting up new sockets