### PR TITLE
Fixing http

### DIFF
--- a/.github/workflows/cmake-multiplatform.yml
+++ b/.github/workflows/cmake-multiplatform.yml
@@ -80,7 +80,8 @@ jobs:
     - name: Test
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       env:
-        ROS_MASTER_URI: http://localhost:11311
+        ROS_MASTER_URI: "http://localhost:11311"
+        ROSCONSOLE_FORMAT: "[${severity}][${nthread}][${time}]: ${message}"
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
@@ -94,6 +95,7 @@ jobs:
       if: ${{ failure() }}  # Run only if something went wrong
       env:
         ROS_MASTER_URI: http://localhost:11311
+        ROSCONSOLE_FORMAT: "[${severity}][${nthread}][${time}]: ${message}"
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |

--- a/.github/workflows/cmake-multiplatform.yml
+++ b/.github/workflows/cmake-multiplatform.yml
@@ -84,8 +84,10 @@ jobs:
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
+        ./bin/manage-master start
         TOOL=gdb ctest --output-on-failure --test-dir test -V --timeout 100 -C ${{env.BUILD_TYPE}}
         ls -alh .
+        ./bin/manage-master stop
 
     - name: Test-memcheck
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
@@ -95,7 +97,9 @@ jobs:
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
+        ./bin/manage-master start
         TOOL=valgrind ctest --output-on-failure --test-dir test -V --timeout 100 -C ${{env.BUILD_TYPE}}
+        ./bin/manage-master stop
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}  # Run only if something went wrong
       with:

--- a/.github/workflows/cmake-multiplatform.yml
+++ b/.github/workflows/cmake-multiplatform.yml
@@ -92,7 +92,8 @@ jobs:
 
     - name: Test-memcheck
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
-      if: ${{ failure() }}  # Run only if something went wrong
+      #if: ${{ failure() }}  # Run only if something went wrong
+      if: false # Temporary disabled.
       env:
         ROS_MASTER_URI: http://localhost:11311
         ROSCONSOLE_FORMAT: "[${severity}][${nthread}][${time}]: ${message}"

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -14,7 +14,7 @@ Here is the list of different envorinment variables, which can influence behavio
 
 **HOME** - the last choice for picking ROS log folder.
 
-**ROSCONSOLE_FORMAT**
+**ROSCONSOLE_FORMAT** - specifies format for logging messages. More details can be found at [logging.md](logging.md)
 
 **ROSCONSOLE_STDOUT_LINE_BUFFERED** - forces buffering of stdout writer. Takes values 0 or 1.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -4,6 +4,16 @@ All miniros modules are logging to `miniros.` channel. `MINIROS_PACKAGE_NAME` ma
 By default `MINIROS_PACKAGE_NAME=unknown_package` will be used. Regular ROS was providing this macro from its CMake scripts.
 Since miniros minimizes usage of external compile options, this macro should be set manually.
 
+Format for logging messages can be overidden by environment variable `ROSCONSOLE_FORMAT`. It is initialized by `[${severity}] [${time}]: ${message}` by default.
+There are following tokens:
+ - message - contains generated message.
+ - severity - log/channel severity.
+ - time - time of log in rostime domain. 
+ - walltime - time of message in system clock domain. It is CLOCK_MONOTONIC time.
+ - file - file from which message is originating. Corresponds to place where MINIROS_LOG is invoked.
+ - function - name of function.
+ - thread - invoking thread. Corresponds to std::thread::id().
+ 
 ## Setting default log levels ## 
 
 Function `miniros::console::set_logger_level(channel, level)` can be used to set initial log levels.
@@ -40,3 +50,4 @@ Some part of internal logging is done through local log to prevent potential rec
  - http::HttpServerConnection
  - http::HttpClient
  - http::HttpRequest
+

--- a/include/minibag/player.h
+++ b/include/minibag/player.h
@@ -40,7 +40,9 @@
   #include <unistd.h>
 #else
   #define WIN32_LEAN_AND_MEAN
-  #define NOMINMAX
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
   #include <windows.h>
 #endif
 

--- a/include/miniros/common.h
+++ b/include/miniros/common.h
@@ -41,7 +41,12 @@ namespace miniros
 {
 
 MINIROS_DECL void disableAllSignalsInThisThread();
+
+/// Set debug-friendly thread name.
 MINIROS_DECL void setThreadName(const char* name);
+
+/// Get debug-friendly thread name.
+MINIROS_DECL std::string getThreadName();
 
 /// Notify system that node has successfully started.
 MINIROS_DECL Error notifyNodeStarted();

--- a/include/miniros/errors.h
+++ b/include/miniros/errors.h
@@ -59,6 +59,10 @@ struct MINIROS_DECL Error {
     ResponsePostponed,
     /// Can not complete operation because of some resource is in use.
     ResourceInUse,
+    /// Connection is refused by server.
+    ConnectionRefused,
+    /// IP address of host is unknown.
+    AddressIsUnknown,
   };
 
   Error() :code(Ok)

--- a/include/miniros/http/endpoint_collection.h
+++ b/include/miniros/http/endpoint_collection.h
@@ -1,0 +1,65 @@
+//
+// Created by dkargin on 3/21/26.
+//
+
+#ifndef MINIROS_ENDPOINT_COLLECTION_H
+#define MINIROS_ENDPOINT_COLLECTION_H
+
+#include <mutex>
+#include <memory>
+
+#include "miniros/macros.h"
+#include "miniros/http/http_endpoint.h"
+#include "miniros/callback_queue.h"
+
+namespace miniros {
+namespace http {
+namespace internal {
+
+/// A collection of http endpoints for server.
+/// This object is shared between http::Server and http::ServerConnection instances.
+class MINIROS_DECL EndpointCollection {
+public:
+  struct Binding {
+    std::unique_ptr<EndpointFilter> filter;
+    std::shared_ptr<EndpointHandler> endpoint;
+    CallbackQueuePtr callbackQueue;
+
+    Binding(std::unique_ptr<EndpointFilter>&& filter, const std::shared_ptr<EndpointHandler>& endpoint, const CallbackQueuePtr& cb)
+      : filter(std::move(filter)), endpoint(endpoint), callbackQueue(cb)
+    {}
+  };
+
+
+  Error registerEndpoint(std::unique_ptr<EndpointFilter>&& filter, const std::shared_ptr<EndpointHandler>& handler, const CallbackQueuePtr& cb)
+  {
+    std::unique_lock lock(guard_);
+    endpoints_.emplace_back(std::move(filter), handler, cb);
+    return Error::Ok;
+  }
+
+  std::pair<std::shared_ptr<EndpointHandler>, std::shared_ptr<CallbackQueue>> findEndpoint(const HttpParserFrame& frame) const
+  {
+    std::unique_lock<std::mutex> lock(guard_);
+
+    for (const Binding& binding: endpoints_) {
+      if (binding.filter->check(frame)) {
+        return {binding.endpoint, binding.callbackQueue};
+      }
+    }
+
+    return {};
+  }
+
+protected:
+  /// A collection of endpoints.
+  std::vector<Binding> endpoints_;
+
+  /// A mutex for endpoints.
+  mutable std::mutex guard_;
+};
+
+}
+}
+}
+#endif // MINIROS_ENDPOINT_COLLECTION_H

--- a/include/miniros/http/http_client.h
+++ b/include/miniros/http/http_client.h
@@ -24,7 +24,13 @@ struct ClientInfo;
 
 namespace http {
 
-/// Persistent HTTP connection.
+/// Persistent connection to remote HTTP server .
+///
+/// Reconnection policy:
+/// HttpClient does not reconnect automatically in case of errors. Instead, it switches to disconnected state and calls
+/// user-provided DisconnectHandler handler. User can choose to call `HttpClient::reconnect` to initiate reconnect after
+/// some specified timeout. Reconnection will go to the same address, specified in HttpClient::connect. All this actions
+/// will be done in PollSet polling thread.
 class MINIROS_DECL HttpClient {
 public:
   using NetSocket = network::NetSocket;
@@ -36,6 +42,8 @@ public:
     enum State_t {
       /// No socket or connection available.
       Invalid,
+      /// Waiting for proper IP address to connect.
+      WaitingAddress,
       /// Connecting to server or on timeout.
       /// Client has some valid socket, valid destination address, but connection is not established.
       /// User can start adding requests to client. They will be processed right after connection is established.
@@ -92,14 +100,6 @@ public:
   ///  - Internal error if internal_ is empty.
   Error dropRequest(const std::shared_ptr<HttpRequest>& request);
 
-  /// Close and release internal data.
-  /// It will:
-  ///  - detach from PollSet
-  ///  - close socket
-  ///  - drop all connections
-  /// It will leave client in Invalid unusable state.
-  void release();
-
   /// Detach from socket.
   std::shared_ptr<network::NetSocket> detach();
 
@@ -114,8 +114,9 @@ public:
   /// Get number of queued requests, including active one.
   size_t getQueuedRequests() const;
 
-  /// Called when TCP connection is broken.
-  using DisconnectHandler = std::function<void (std::shared_ptr<NetSocket>& socket, State state)>;
+  /// DisconnectHandler is called by PollSet thread when TCP connection is broken or some serious error happens.
+  /// User can call `HttpClient::reconnect` to initiate reconnect.
+  using DisconnectHandler = std::function<void (std::shared_ptr<NetSocket>& socket, State state, Error error)>;
 
   /// Sets callback for disconnect event.
   /// Handler will be called when disconnect will happen. It can be during async connection, or any other active state.
@@ -166,6 +167,14 @@ protected:
 
   /// Handle socket events from PollSet.
   static int handleSocketEvents(const std::shared_ptr<Internal>& I, int events);
+
+  /// Close and release internal data.
+  /// It will:
+  ///  - detach from PollSet
+  ///  - close socket
+  ///  - drop all connections
+  /// It will leave client in Invalid unusable state.
+  void release();
 
 private:
   /// Shared pointer is used to resolve racing condition with handleEvent callback from other thread.

--- a/include/miniros/http/http_client.h
+++ b/include/miniros/http/http_client.h
@@ -166,7 +166,7 @@ protected:
   struct Internal;
 
   /// Handle socket events from PollSet.
-  static int handleSocketEvents(const std::shared_ptr<Internal>& I, int events);
+  static void handleSocketEvents(const std::shared_ptr<Internal>& I, int events);
 
   /// Close and release internal data.
   /// It will:

--- a/include/miniros/http/http_server.h
+++ b/include/miniros/http/http_server.h
@@ -71,6 +71,10 @@ protected:
   /// Close connection and send all notifications.
   void closeConnection(int fd, const std::string& reason);
 
+  /// Creates HTTP connection.
+  /// This method is virtual to be able to override it in tests.
+  virtual std::shared_ptr<HttpServerConnection> makeConnection(const std::shared_ptr<network::NetSocket>& socket);
+
 protected:
   struct Internal;
   std::unique_ptr<Internal> internal_;

--- a/include/miniros/http/http_server.h
+++ b/include/miniros/http/http_server.h
@@ -35,6 +35,9 @@ public:
   /// Start server on specific port.
   Error start(int port);
 
+  /// Start IPv6 server on sepecific port.
+  Error start6(int port);
+
   /// Stop all sockets.
   Error stop();
 
@@ -64,10 +67,6 @@ public:
 
 protected:
   friend class HttpServerConnection;
-  /// Accept client and add it to event processing.
-  /// For internal usage only.
-  /// @param sock - listening socket.
-  void acceptClient(const std::shared_ptr<Lifetime<HttpServer>>& lifetime, network::NetSocket* sock);
 
   /// It is called by HttpServerConnection when it is closed by any reason.
   void onConnectionClosed(const std::shared_ptr<HttpServerConnection>& connection, const std::string& reason);

--- a/include/miniros/http/http_server.h
+++ b/include/miniros/http/http_server.h
@@ -35,7 +35,7 @@ public:
   /// Start server on specific port.
   Error start(int port);
 
-  /// Start IPv6 server on sepecific port.
+  /// Start IPv6 server on specific port.
   Error start6(int port);
 
   /// Stop all sockets.

--- a/include/miniros/http/http_server.h
+++ b/include/miniros/http/http_server.h
@@ -15,7 +15,7 @@ namespace miniros {
 
 class PollSet;
 class CallbackQueue;
-template <class T> struct Lifetime;
+template <class T> class Lifetime;
 
 namespace network {
 class NetSocket;
@@ -30,7 +30,7 @@ class HttpServerConnection;
 class HttpServer {
 public:
   HttpServer(PollSet* pollSet);
-  ~HttpServer();
+  virtual ~HttpServer();
 
   /// Start server on specific port.
   Error start(int port);
@@ -63,13 +63,14 @@ public:
   void setCloseConnectionHandler(CloseConnectionHandler&& handler);
 
 protected:
+  friend class HttpServerConnection;
   /// Accept client and add it to event processing.
   /// For internal usage only.
   /// @param sock - listening socket.
   void acceptClient(const std::shared_ptr<Lifetime<HttpServer>>& lifetime, network::NetSocket* sock);
 
-  /// Close connection and send all notifications.
-  void closeConnection(int fd, const std::string& reason);
+  /// It is called by HttpServerConnection when it is closed by any reason.
+  void onConnectionClosed(const std::shared_ptr<HttpServerConnection>& connection, const std::string& reason);
 
   /// Creates HTTP connection.
   /// This method is virtual to be able to override it in tests.

--- a/include/miniros/http/http_server_connection.h
+++ b/include/miniros/http/http_server_connection.h
@@ -18,6 +18,10 @@ namespace miniros {
 
 namespace http {
 
+namespace internal {
+class EndpointCollection;
+}
+
 class HttpServer;
 
 /// A Connection to HttpServer from Client.
@@ -26,6 +30,8 @@ class HttpServerConnection : public std::enable_shared_from_this<HttpServerConne
 public:
   HttpServerConnection(HttpServer* server, std::shared_ptr<network::NetSocket> socket, PollSet* pollSet);
   ~HttpServerConnection();
+
+  void setEndpointCollection(const std::shared_ptr<internal::EndpointCollection>& endpoints);
 
   /// Handler for socket/poll events.
   /// @param evtFlags event flags from poll
@@ -131,6 +137,8 @@ protected:
   PollSet* poll_set_ = nullptr;
 
   mutable std::mutex guard_;
+
+  std::weak_ptr<const internal::EndpointCollection> endpoints_;
 };
 
 }

--- a/include/miniros/http/http_server_connection.h
+++ b/include/miniros/http/http_server_connection.h
@@ -11,8 +11,6 @@
 #include "miniros/http/http_tools.h"
 #include "miniros/http/http_request.h"
 
-#include "miniros/steady_timer.h"
-
 
 namespace miniros {
 
@@ -38,8 +36,7 @@ public:
 
   /// Handler for socket/poll events.
   /// @param evtFlags event flags from poll
-  /// @returns new event mask
-  int handleEvents(int evtFlags);
+  void handleEvents(int evtFlags);
 
   struct MINIROS_DECL State {
     enum State_t {

--- a/include/miniros/http/http_server_connection.h
+++ b/include/miniros/http/http_server_connection.h
@@ -28,10 +28,13 @@ class HttpServer;
 /// It handles parsing HTTP request from client, picking right endpoint handler and sending response back.
 class HttpServerConnection : public std::enable_shared_from_this<HttpServerConnection> {
 public:
-  HttpServerConnection(HttpServer* server, std::shared_ptr<network::NetSocket> socket, PollSet* pollSet);
+  HttpServerConnection(const std::shared_ptr<Lifetime<HttpServer>>& server,
+    std::shared_ptr<network::NetSocket> socket);
   ~HttpServerConnection();
 
   void setEndpointCollection(const std::shared_ptr<internal::EndpointCollection>& endpoints);
+
+  void attachPollSet(PollSet* pollSet);
 
   /// Handler for socket/poll events.
   /// @param evtFlags event flags from poll
@@ -66,15 +69,15 @@ public:
 
   void resetResponse();
 
-  /// Close connection.
-  void close();
+  /// Get internal file descriptor/socket.
+  int fd() const;
 
   /// Fill in fault response.
   static void prepareFaultResponse(Error error, http::HttpRequest& request);
 
   /// Detach from server.
   /// Breaks link with Http server.
-  void detach();
+  void detachFromServer(bool close);
 
   using Lock = TimeCheckLock<std::mutex>;
 
@@ -85,6 +88,9 @@ public:
   void onAsyncRequestComplete(std::shared_ptr<HttpRequest> request, Error err);
 
   int eventsForState(State state) const;
+
+  /// Check if this connection is detached from HTTP server instance.
+  bool isDetachedFromParent() const;
 
 protected:
   /// Updates internal state.
@@ -114,9 +120,12 @@ protected:
   /// Start writing response to socket. It serializes response to buffers and switches state to WriteResponse.
   void doWriteResponse(Lock& lock, const std::shared_ptr<HttpRequest>& requestObject, Error error);
 
+  /// Close and drop socket.
+  void closeSocket();
+
   State state_ = State::ReadRequest;
 
-  HttpServer* server_;
+  std::shared_ptr<Lifetime<HttpServer>> server_lifetime_;
 
   HttpParserFrame http_frame_;
 

--- a/include/miniros/internal/code_location.h
+++ b/include/miniros/internal/code_location.h
@@ -78,7 +78,7 @@ protected:
 
 }
 
-#define THIS_LOCATION internal::CodeLocation::make(__FILE__, __LINE__)
+#define THIS_LOCATION ::miniros::internal::CodeLocation::make(__FILE__, __LINE__)
 
 }
 #endif // MINIROS_CODE_LOCATION_H

--- a/include/miniros/internal/lifetime.h
+++ b/include/miniros/internal/lifetime.h
@@ -13,20 +13,66 @@ namespace miniros {
 /// can be called in the same moment destructor runs.
 /// Template parameter is used to distinguish lifetimes of different types of objects in valgrind/helgrind.
 template <class T>
-struct Lifetime {
+class Lifetime {
+public:
+  Lifetime(T* object) : object_(object) {}
   virtual ~Lifetime() {}
-  std::mutex mutex;
-  bool alive = true;
 
-  void lock()
+  using Lock = std::unique_lock<std::mutex>;
+
+  void lock() const
   {
-    mutex.lock();
+    mutex_.lock();
   }
 
-  void unlock()
+  void unlock() const
   {
-    mutex.unlock();
+    mutex_.unlock();
   }
+
+  /// Check if internal object is valid.
+  bool valid(Lock& /*lock*/) const
+  {
+    return object_ != nullptr;
+  }
+
+  /// Reset pointer to object.
+  /// Lifetime becomes invalid.
+  void reset()
+  {
+    Lock lock(mutex_);
+    object_ = nullptr;
+  }
+
+  Lock getLock() const
+  {
+    return Lock(mutex_);
+  }
+
+  /// Reset pointer to object.
+  /// This function assumes that lock is already acquired by getLock().
+  void reset(Lock& /*lock*/)
+  {
+    object_ = nullptr;
+  }
+
+  /// Get internal pointer.
+  /// Lifetime object must be locked beforehand.
+  T* ptr()
+  {
+    return object_;
+  }
+
+  /// Get internal pointer.
+  /// Lifetime object must be locked beforehand.
+  const T* ptr() const
+  {
+    return object_;
+  }
+
+protected:
+  mutable std::mutex mutex_;
+  T* object_ = nullptr;
 };
 
 }

--- a/include/miniros/io/poll_set.h
+++ b/include/miniros/io/poll_set.h
@@ -52,6 +52,13 @@ namespace miniros
  *
  * Warning: PollSet must not use rosconsole in any way. This class is used too early
  * and used for all socket interactions, including rosconsole.
+ *
+ * There are two mutually exclusive strategies for updating events on sockets: direct set/add/delEvents and EventUpdate from callback.
+ * 1. Direct set/add/delEvents. It should be used when PollSet thread can not be the only thread to update event flags, like HttpClient.
+ *    Most of changes to event flags are done from event handler from polling thread. But occasional calls to enqueue(Request) from
+ *    different thread require mutex to lock both event flags and internal state of HttpClient.
+ * 2. EventUpdate method: event handler returns new set of event flags. This method can be used only if changes to event flags
+ *    can happen only from event handler. This method was used mostly by objects in XmlRpc.
  */
 class MINIROS_DECL PollSet
 {

--- a/include/miniros/io/poll_set.h
+++ b/include/miniros/io/poll_set.h
@@ -59,7 +59,6 @@ public:
   PollSet();
   ~PollSet();
 
-
   /// Use this flag to subscribe to "input" events. They are equal to POLLIN.
   static const int EventIn;
   /// Use this flag to get notified when output is possible. It is equal to POLLOUT.
@@ -69,11 +68,14 @@ public:
 
   /// Low precision timer event.
   static constexpr int EventTimer = 1<<29;
+
   /// Add this evt flag to update event flags by return value from SocketUpdateFunc.
+  /// NOTE: This mechanic is dangerous and leads to racing conditions in a big components.
   static constexpr int EventUpdate = 1 << 30;
 
   /// Drop FD from poll set.
   /// It can be returned by event handler.
+  /// NOTE: This mechanic is dangerous and leads to racing conditions in a big components.
   static const int ResultDropFD = 1 << 24;
 
   /// Object to be kept back during active callback.
@@ -81,7 +83,6 @@ public:
 
   typedef std::function<int (int)> SocketUpdateFunc;
 
-  typedef std::function<void (int)> SocketUpdateVoidFunc;
   /**
    * \brief Add a socket.
    *

--- a/include/miniros/network/net_address.h
+++ b/include/miniros/network/net_address.h
@@ -63,6 +63,9 @@ public:
   /// Generate string representation of an address.
   std::string str() const;
 
+  /// Generate longer string representation of an address.
+  std::string lstr() const;
+
   /// Check type of provided address in a string form.
   static Type checkAddressType(const std::string& address);
 

--- a/include/miniros/network/net_address.h
+++ b/include/miniros/network/net_address.h
@@ -21,10 +21,13 @@ class MINIROS_DECL NetAddress {
 public:
   enum Type {
     AddressInvalid,
-    AddressIPv4,
-    AddressIPv6,
     /// Unspecified address type. Used for creating NetAddress address from arbitrary hostname.
     AddressUnspecified,
+
+    AddressIPv4,
+    AddressIPv6,
+
+    // AddressUnix.
   };
 
   /// String representation of network address.
@@ -138,6 +141,9 @@ MINIROS_DECL Error readRemoteAddress(int sockfd, NetAddress& address);
 
 /// Fill in broadcast address with specific port.
 MINIROS_DECL Error fillBroadcastAddress(NetAddress& address, int port, NetAddress::Type type);
+
+/// Make network address from string.
+MINIROS_DECL Error addressFromString(NetAddress::Type type, const std::string& address, int port, NetAddress& result);
 
 /// Information about connection to client.
 struct MINIROS_DECL ClientInfo {

--- a/include/miniros/network/socket.h
+++ b/include/miniros/network/socket.h
@@ -35,6 +35,25 @@ public:
     UDPv6
   };
 
+  /// Some high level state of a socket.
+  enum class State {
+    /// Socket is in invalid state. No fd is assigned.
+    Invalid,
+    /// Socket is just created.
+    /// UDP sockets are staying in this state forever.
+    Initial,
+    /// Socket is in listening state.
+    /// Corresponds to TCP listening socket.
+    Listening,
+    /// TCP socket is connecting somewhere.
+    Connecting,
+
+    Connected,
+
+    /// Adopted external file descriptor without knowing its actual state.
+    Unknown,
+  };
+
   /// Creates object without any bound socket.
   NetSocket();
 
@@ -42,7 +61,7 @@ public:
   /// @param fd - socket file descriptor
   /// @param type - socket type.
   /// @param own - should socket completely own descriptor and close it in destructor.
-  NetSocket(int fd, Type type, bool own);
+  NetSocket(int fd, Type type, bool own, State state = State::Unknown);
 
   virtual ~NetSocket();
 
@@ -71,11 +90,16 @@ public:
 
   Error setKeepAlive(bool keepAlive);
 
+  /// Initialize TCP socket.
+  Error tcpSocket(NetAddress::Type type);
+
   /// Allocate tcp port and start listening.
+  /// It can potentially change file descriptor.
   Error tcpListen(int port, NetAddress::Type type, int maxQueuedClients=100);
 
   /// Connect to specified TCP address.
   /// Previous connection will be immediately closed.
+  /// It can potentially change internal file descriptor.
   /// @param address - destination address
   /// @param nonblock - connect in nonblock mode. Actual state should be processed by PollSet.
   /// @returns possible errors:
@@ -88,7 +112,6 @@ public:
   /// Enter listening mode.
   /// Socket must be already created.
   Error listen(int maxQueuedClients);
-
 
   /// Initialize UDP ipv4 socket.
   /// @param ip6 - should create ipv6 socket.
@@ -110,6 +133,7 @@ public:
   bool valid() const;
 
   /// Close and reset socket.
+  /// Socket will return to `State::Invalid`.
   void close();
 
   /// Check if socket is in datagram mode.
@@ -126,6 +150,9 @@ public:
 
   /// Check if socket is connecting to remote host.
   bool isConnecting() const;
+
+  /// Check if socket is already in connected state.
+  bool isConnected() const;
 
   /// Check if connection is complete and clear connecting flag.
   /// @returns:
@@ -163,6 +190,10 @@ public:
   /// Get system error from socket.
   /// It can be used to extract error when poll/epoll returned POLLERR event.
   int getSysError() const;
+
+  /// Terminate active connection.
+  /// Socket will return to Initial state, preserving current fd.
+  void disconnect();
 
 protected:
   struct Internal;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -57,6 +57,9 @@
 
 #include "internal_config.h"
 
+#include <mutex>
+#include <thread>
+
 #ifdef HAVE_GLIBC_BACKTRACE
 #include <execinfo.h>  // For backtrace()
 #endif
@@ -92,6 +95,9 @@ void disableAllSignalsInThisThread()
 #endif
 }
 
+std::map<std::thread::id, std::string> g_nice_thread_names;
+std::mutex g_nice_thread_mutex;
+
 // Following advice at https://stackoverflow.com/questions/10121560/stdthread-naming-your-thread
 void setThreadName(const char* threadName) {
 #if defined(_WIN32)
@@ -103,6 +109,20 @@ void setThreadName(const char* threadName) {
   pthread_setname_np(handle, threadName);
 #endif
   profiling::writeCurrentThreadNameInTrace(threadName);
+  std::unique_lock lock(g_nice_thread_mutex);
+  g_nice_thread_names[std::this_thread::get_id()] = threadName;
+}
+
+std::string getThreadName()
+{
+  std::unique_lock lock(g_nice_thread_mutex);
+  auto id = std::this_thread::get_id();
+  if (auto it = g_nice_thread_names.find(id); it != g_nice_thread_names.end()) {
+    return it->second;
+  }
+  std::stringstream ss;
+  ss << id;
+  return ss.str();
 }
 
 #ifdef MINIROS_USE_LIBSYSTEMD

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -16,7 +16,6 @@ const char* Error::toString() const {
       return "Invalid value";
     case Error::OutOfMemory:
       return "Out of memory";
-
     case Error::NotImplemented:
       return "Not implemented";
     case Error::NotSupported:
@@ -53,6 +52,10 @@ const char* Error::toString() const {
       return "ResponsePostponed";
     case Error::ResourceInUse:
       return "ResourceInUse";
+    case Error::ConnectionRefused:
+      return "Connection Refused";
+    case Error::AddressIsUnknown:
+      return "Address is unknown";
   }
   return "Unknown error";
 }

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -29,6 +29,8 @@ const char* HttpClient::State::toString() const
   switch (value) {
     case Invalid:
       return "Invalid";
+    case WaitingAddress:
+      return "WaitingAddress";
     case Connecting:
       return "Connecting";
     case WaitReconnect:
@@ -56,12 +58,10 @@ bool HttpClient::State::hasRequest() const
 
 
 struct HttpClient::Internal {
-
   DisconnectHandler onDisconnect;
-
   ConnectHandler onConnect;
-
   ResponseHandler onResponse;
+
   /// Idle timeout handler and timeout value.
   TimeoutHandler onIdleTimeout;
   int idleTimeoutMs = 0;
@@ -78,6 +78,10 @@ struct HttpClient::Internal {
   /// Remote address.
   /// It is set during `connect` call and reused in reconnects.
   network::NetAddress address;
+  /// Host and port as specified by `HttpClient::connect`.
+  /// Unlike `address`, this may remain unresolved hostname.
+  std::string remoteHost;
+  int remotePort = 0;
 
   /// Internal state.
   State state = State::Invalid;
@@ -98,11 +102,16 @@ struct HttpClient::Internal {
 
   /// Serving PollSet.
   PollSet* poll_set = nullptr;
+  bool poll_registered = false;
 
   /// Mutex for processing socket state.
   std::mutex process_guard;
 
   std::atomic_int updateCounter = 0;
+
+  /// True if owning HttpClient is still alive.
+  /// It is set to false in ~HttpClient()
+  std::atomic_bool alive{true};
 
   /// Condition variable for state change.
   std::condition_variable_any cv;
@@ -129,20 +138,24 @@ struct HttpClient::Internal {
   /// Get socket events for specified state.
   int eventsForState(State state) const;
 
-
-
   /// Does actual connection.
   /// @param I - reference to self/Internal. Used to keep instance alive.
   /// @param lock - reference to locked mutex. Used to enforce locking before entrance to this method.
   /// @param newAddress - address for connection.
   Error connectImpl(const std::shared_ptr<Internal>& I, Lock& lock, const network::NetAddress& newAddress);
 
-  void handleDisconnect(Lock& lock);
+  void handleDisconnect(Lock& lock, Error disconnectError);
 
   /// Handle State::Connecting.
   /// Can switch to Idle.
   /// It is expected that idle state is handled right after 'handleConnecting'
   void handleConnecting(Lock& lock, int evtFlags);
+
+  /// Handle State::WaitAddress.
+  /// Can switch to:
+  ///    - Connecting
+  ///    - Invalid
+  void handleWaitAddress(const std::shared_ptr<Internal>& I, Lock& lock, int events);
 
   /// Handle State::Reconnecting.
   /// Can switch to:
@@ -176,27 +189,15 @@ struct HttpClient::Internal {
 
   void updateState(Lock& lock, State newState);
 
-  void detachSocket(Lock& lock)
-  {
-    if (socket && poll_set) {
-      poll_set->delSocket(socket->fd());
-    }
-  }
-
-  void closeSocket(Lock& lock)
-  {
-    if (socket) {
-      socket->close();
-      socket.reset();
-    }
-  }
-
   /// Pulls new task from queue and updates state.
   /// @returns true if managed to pull new task.
   bool pullNewTask(Lock& processLock);
 
   /// Completely release own state.
   void release(Lock& lock);
+
+  ///  Attach socket to PollSet.
+  bool initSocketEvents(const std::shared_ptr<Internal>& I, Lock& /*lock*/);
 
   size_t getQueuedRequests() const
   {
@@ -211,9 +212,18 @@ struct HttpClient::Internal {
 void HttpClient::Internal::release(Lock& lock)
 {
   LOCAL_DEBUG("HttpClient::Internal[%d]::release()", fd());
-  detachSocket(lock);
-  closeSocket(lock);
+  if (socket && poll_set && poll_registered) {
+    poll_set->delSocket(socket->fd());
+    poll_registered = false;
+  }
+
+  onConnect = {};
+  onDisconnect = {};
+  onIdleTimeout = {};
+  onResponse = {};
+
   updateState(lock, State::Invalid);
+  socket.reset();
 
   std::shared_ptr<HttpRequest> activeReq;
   std::deque<std::shared_ptr<HttpRequest>> requestsCopy;
@@ -315,19 +325,24 @@ bool HttpClient::Internal::pullNewTask(Lock& processLock)
   active_request->updateState(HttpRequest::State::ClientSending);
   active_request->setRequestStart(SteadyTime::now());
 
-  // Build request header from HttpRequest (host/port managed by HttpClient)
-  request_header_buffer = active_request->buildHeader(address.address, address.port());
+  // Build request header from HttpRequest (host/port managed by HttpClient).
+  // Use configured host/port from connect() to preserve original host name.
+  const std::string& requestHost = remoteHost.empty() ? address.address : remoteHost;
+  const int requestPort = remotePort > 0 ? remotePort : address.port();
+  request_header_buffer = active_request->buildHeader(requestHost, requestPort);
   request_body = active_request->requestBody();
   data_sent = 0;
 
   return true;
 }
 
-void HttpClient::Internal::handleDisconnect(Lock& lock)
+void HttpClient::Internal::handleDisconnect(Lock& lock, Error disconnectError)
 {
   State stateCopy = state;
 
-  poll_set->setEvents(fd(), 0);
+  if (socket && socket->valid()) {
+    poll_set->setEvents(fd(), 0);
+  }
   updateState(lock, State::Disconnected);
   // Push active request back to queue.
   if (active_request) {
@@ -352,16 +367,16 @@ void HttpClient::Internal::handleDisconnect(Lock& lock)
     }
   }
 
-  // No callback set or no reconnect required. Just close the current socket astd::strchr(nd reset state.
   LOCAL_INFO("HttpClient[%s]::handleDisconnect() - connection is closed from state %s", debugName().c_str(), stateCopy.toString());
 
-  if (onDisconnect) {
+  if (onDisconnect && alive) {
     // Copying all mutable data, which can be changed during callback.
     auto callback = onDisconnect;
     auto socketCopy = socket;
     ScopedUnlock unlock(lock);
-    // User can issue reconnect right here.
-    callback(socketCopy, stateCopy);
+    // Danger: if callback references HttpClient object then there is small chance
+    // this instance is destroyed right after lock is released.
+    callback(socketCopy, stateCopy, disconnectError);
   }
 }
 
@@ -394,10 +409,11 @@ void HttpClient::setIdleTimeoutHandler(int timeoutMs, TimeoutHandler&& handler)
 {
   if (!internal_)
     return;
+
   Lock lock(internal_->process_guard, THIS_LOCATION);
   internal_->onIdleTimeout = std::move(handler);
   internal_->idleTimeoutMs = timeoutMs;
-  
+
   // If we're currently in Idle state and have a valid socket, set the timer
   if (internal_->state == State::Idle && internal_->socket && internal_->poll_set && timeoutMs > 0) {
     internal_->poll_set->setTimerEvent(internal_->socket->fd(), timeoutMs);
@@ -411,17 +427,39 @@ Error HttpClient::reconnect(int timeoutMs)
     return Error::InternalError;
 
   Lock lock(internal_->process_guard, THIS_LOCATION);
+  //if (internal_->remoteHost.empty() || internal_->remotePort <= 0)
+  //  return Error::InvalidAddress;
 
-  if (!internal_->socket || !internal_->socket->valid())
-    return Error::InvalidHandle;
+  network::NetAddress newAddress;
+  Error resolveErr = network::addressFromString(network::NetAddress::AddressUnspecified,
+    internal_->remoteHost, internal_->remotePort, newAddress);
+
+  bool needAddress = false;
+  if (!resolveErr) {
+    if (resolveErr == Error::AddressIsUnknown) {
+      // Can continue reconnect
+      needAddress = true;
+    } else {
+      MINIROS_ERROR("Failed to make address for reconnection: %s", resolveErr.toString());
+      return resolveErr;
+    }
+  }
+
+  internal_->reconnectAttempts++;
 
   if (timeoutMs > 0) {
+    // Really expect socket to exist, even in some placeholder form.
+    assert(internal_->socket && internal_->socket->valid());
+    if (!internal_->socket || !internal_->socket->valid()) {
+      return Error::InvalidHandle;
+    }
+    internal_->updateState(lock, needAddress ? State::WaitingAddress : State::WaitReconnect);
     internal_->poll_set->setTimerEvent(internal_->socket->fd(), timeoutMs);
-    internal_->updateState(lock, State::WaitReconnect);
     return Error::Ok;
   }
-  internal_->reconnectAttempts++;
-  return internal_->connectImpl(internal_, lock, internal_->address);
+
+  // Immediate connection.
+  return internal_->connectImpl(internal_, lock, newAddress);
 }
 
 Error HttpClient::Internal::readResponse()
@@ -470,6 +508,7 @@ HttpClient::~HttpClient()
     fd = internal_->fd();
     std::shared_ptr<Internal> copy;
     std::swap(internal_, copy);
+    copy->alive = false;
     copy->release(lock);
     refs = copy.use_count();
     // Explicitly unlock to prevent potential deadlock in destructor if Internal.
@@ -629,11 +668,29 @@ Error HttpClient::dropRequest(const std::shared_ptr<HttpRequest>& request)
 
 Error HttpClient::connect(const std::string& host, int port)
 {
-  network::NetAddress address = network::NetAddress::fromString(network::NetAddress::AddressIPv4, host, port);
-  if (!address.valid())
-    return Error::InvalidAddress;
+  network::NetAddress address;
+  Error resolveErr = network::addressFromString(network::NetAddress::AddressUnspecified, host, port, address);
+
+  if (!resolveErr && resolveErr != Error::AddressIsUnknown) {
+    // Some unrecoverable error, which prevents any further connection.
+    return resolveErr;
+  }
 
   Lock lock(internal_->process_guard, THIS_LOCATION);
+  internal_->remoteHost = host;
+  internal_->remotePort = port;
+
+  if (resolveErr == Error::AddressIsUnknown) {
+    if (!internal_->socket) {
+      // Just create some dummy socket, so it is eligible for adding into PollSet with no events.
+      internal_->socket.reset(new NetSocket());
+      internal_->socket->tcpSocket(network::NetAddress::Type::AddressIPv4);
+      internal_->initSocketEvents(internal_, lock);
+    }
+    internal_->handleDisconnect(lock, Error::AddressIsUnknown);
+    return Error::Ok;
+  }
+
   return internal_->connectImpl(internal_, lock, address);
 }
 
@@ -647,16 +704,19 @@ int HttpClient::getReconnectAttempts() const
 
 Error HttpClient::Internal::connectImpl(const std::shared_ptr<Internal>& I, Lock& lock, const network::NetAddress& newAddress)
 {
-  assert(poll_set);
   if (!poll_set) {
     return Error::InternalError;
   }
 
-  if (socket && socket->valid()) {
-    detachSocket(lock);
+  if (!socket) {
+    socket.reset(new NetSocket());
+    socket->setKeepAlive(true);
+  } else if (socket->valid()) {
+    socket->disconnect();
+    // Socket's FD can be changed during tcpConnect, so we must detach it from poll_set and reattach after we initiate connection.
+    poll_set->delSocket(socket->fd());
+    poll_registered = false;
   }
-
-  socket.reset(new NetSocket());
 
   Error err = socket->tcpConnect(newAddress, true);
 
@@ -676,33 +736,48 @@ Error HttpClient::Internal::connectImpl(const std::shared_ptr<Internal>& I, Lock
     return err;
   }
 
-  socket->setKeepAlive(true);
-  poll_set->addSocket(socket->fd(), PollSet::EventIn | PollSet::EventOut | PollSet::EventUpdate | PollSet::EventError,
-    [wptr = std::weak_ptr(I)](int event)
-    {
-      auto ptr = wptr.lock();
-      if (ptr)
-        return handleSocketEvents(ptr, event);
-      return 0;
-    }, I, THIS_LOCATION);
-
   updateState(lock, connected ? State::Idle : State::Connecting);
+
+  initSocketEvents(I, lock);
+
   return Error::Ok;
 }
+
+bool HttpClient::Internal::initSocketEvents(const std::shared_ptr<Internal>& I, Lock& /*lock*/)
+{
+  const int events = eventsForState(state) | PollSet::EventUpdate;
+  poll_registered = poll_set->addSocket(socket->fd(), events,
+    [wptr = std::weak_ptr(I)](int event)
+      {
+        auto ptr = wptr.lock();
+        if (ptr)
+          return handleSocketEvents(ptr, event);
+        return 0;
+      }, I, THIS_LOCATION);
+  return poll_registered;
+}
+
 
 Error HttpClient::waitConnected(const WallDuration& duration)
 {
   if (!internal_)
     return Error::InternalError;
+
   if (!internal_->socket || !internal_->socket->valid())
     return Error::InvalidHandle;
 
   std::unique_lock lock(internal_->process_guard);
   if (internal_->cv.wait_for(lock, std::chrono::duration<double>(duration.toSec()),
     [this]() {
-      if (internal_->state == State::Connecting)
-        return false;
-      return true;
+      switch (internal_->state) {
+        case State::ProcessResponse:
+        case State::Idle:
+        case State::ReadResponse:
+        case State::WriteRequest:
+          return true;
+        default:
+          return false;
+      }
     })) {
     if (internal_->state == State::Idle)
       return Error::Ok;
@@ -716,6 +791,10 @@ int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFl
 {
   if (!I)
     return 0;
+
+  // TODO: Disable it once most transport bugs are resolved.
+  LOCAL_DEBUG("HttpClient[%s]::handleSocketEvents(%s) in state %s", I->debugName().c_str(),
+    PollSet::eventToString(evtFlags).c_str(), I->state.toString());
 
   MINIROS_PROFILE_SCOPE2("HttpClient", "handleSocketEvents");
 
@@ -737,6 +816,14 @@ int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFl
       evtFlags = 0;
       break;
     }
+    if (state == State::WaitingAddress) {
+      // Expecting to be here on a timeout.
+      I->handleWaitAddress(I, lock, evtFlags);
+      if (state == State::Invalid)
+        break;
+      evtFlags = 0;
+      stateChanges++;
+    }
     if (state == State::WaitReconnect) {
       // Expecting to be here on a timeout.
       I->handleReconnecting(I, lock, evtFlags);
@@ -756,7 +843,7 @@ int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFl
     if (state == State::Idle) {
       if (evtFlags & PollSet::EventError) {
         // Can we actually be here?
-        I->handleDisconnect(lock);
+        I->handleDisconnect(lock, Error::SystemError);
       } else if (evtFlags & PollSet::EventIn) {
         // Not expecting to read anything. But we can get this event to call 'read' and receive 0 bytes.
         // This is disconnect event.
@@ -816,10 +903,28 @@ int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFl
   return I->eventsForState(I->state);
 }
 
+void HttpClient::Internal::handleWaitAddress(const std::shared_ptr<Internal>& I, Lock& lock, int events)
+{
+  if (events & PollSet::EventTimer) {
+    MINIROS_DEBUG_NAMED("client", "HttpClient[%s]::handleWaitAddress(%s) - retry address", debugName().c_str(), PollSet::eventToString(events).c_str());
+
+    Error resolveErr = network::addressFromString(network::NetAddress::AddressUnspecified, remoteHost, remotePort, address);
+    if (!resolveErr) {
+      handleDisconnect(lock, resolveErr);
+    } else {
+      // Now we have proper address.
+      connectImpl(I, lock, address);
+    }
+  } else if (events & PollSet::EventError) {
+  } else {
+    LOCAL_ERROR("HttpClient[%s]::handleWaitAddress(%s) - unhandled events", debugName().c_str(), PollSet::eventToString(events).c_str());
+  }
+}
+
 void HttpClient::Internal::handleReconnecting(const std::shared_ptr<Internal>& I, Lock& lock, int events)
 {
   if (events & PollSet::EventTimer) {
-    MINIROS_DEBUG_NAMED("client", "HttpClient[%s]::handleReconnecting(%s) - connected", debugName().c_str(), PollSet::eventToString(events).c_str());
+    MINIROS_DEBUG_NAMED("client", "HttpClient[%s]::handleReconnecting(%s) - retry connect", debugName().c_str(), PollSet::eventToString(events).c_str());
     connectImpl(I, lock, address);
   } else if (events & PollSet::EventError) {
   } else {
@@ -837,7 +942,7 @@ void HttpClient::Internal::handleConnecting(Lock& lock, int evtFlags)
   assert(socket->isConnecting());
   if (evtFlags & PollSet::EventError) {
     LOCAL_ERROR("HttpClient[%s]::handleEvents(state=Connecting, evt=%s) - failed to connect, q=%zu", debugName().c_str(), PollSet::eventToString(evtFlags).c_str(), getQueuedRequests());
-    handleDisconnect(lock);
+    handleDisconnect(lock, Error::ConnectionRefused);
     return;
   }
 
@@ -852,9 +957,18 @@ void HttpClient::Internal::handleConnecting(Lock& lock, int evtFlags)
       // Attempt to pull requests will be done in "handleSocketEvents" method.
       reconnectAttempts = 0;
       updateState(lock, State::Idle);
+
+      if (onConnect && alive) {
+        auto callback = onConnect;
+        auto socketCopy = socket;
+        ScopedUnlock unlock(lock);
+        // Danger: if callback references HttpClient object then there is small chance
+        // this instance is destroyed right after lock is released.
+        (void)callback(socketCopy);
+      }
     } else {
-      LOCAL_ERROR("HttpClient[%s]::handleEvents(state=Connecting) - error: %s", debugName().c_str(), err.toString());
-      handleDisconnect(lock);
+      LOCAL_ERROR("HttpClient[%s]::handleEvents(state=Connecting) - checkConnected() error: %s", debugName().c_str(), err.toString());
+      handleDisconnect(lock, err);
     }
   }
 }
@@ -866,7 +980,7 @@ void HttpClient::Internal::handleWriteRequest(Lock& lock, int evtFlags, bool fal
     int err = socket->getSysError();
     // Here we can have some disconnect problem or some generic network problem.
     LOCAL_WARN("HttpClient[%s]::handleWriteRequest socket error in WriteRequest: %i", debugName().c_str(), err);
-    handleDisconnect(lock);
+    handleDisconnect(lock, Error::SystemError);
     return;
   }
 
@@ -901,7 +1015,7 @@ void HttpClient::Internal::handleWriteRequest(Lock& lock, int evtFlags, bool fal
 
     if (err != Error::Ok) {
       LOCAL_ERROR("HttpClient[%s]::handleWriteRequest error: %s", debugName().c_str(), err.toString());
-      handleDisconnect(lock);
+      handleDisconnect(lock, Error::SystemError);
       return;
     }
 
@@ -932,7 +1046,7 @@ void HttpClient::Internal::handleReadResponse(Lock& lock, int evtFlags, bool fal
 
   if (evtFlags & PollSet::EventError) {
     LOCAL_WARN("HttpClient[%s]::handleReadResponse() got socket error", debugName().c_str());
-    handleDisconnect(lock);
+    handleDisconnect(lock, Error::SystemError);
     return;
   }
 
@@ -948,10 +1062,10 @@ void HttpClient::Internal::handleReadResponse(Lock& lock, int evtFlags, bool fal
     else if (err == Error::EndOfFile) {
       LOCAL_INFO("HttpClient[%s] - Got end of file from remote server", debugName().c_str());
       // Connection closed by peer
-      handleDisconnect(lock);
+      handleDisconnect(lock, err);
     } else {
       LOCAL_ERROR("HttpClient[%s] - Unexpected error %s", debugName().c_str(), err.toString());
-      handleDisconnect(lock);
+      handleDisconnect(lock, err);
     }
   } else {
     std::string evt = PollSet::eventToString(evtFlags);
@@ -983,10 +1097,12 @@ void HttpClient::Internal::handleProcessResponse(Lock& lock)
     MINIROS_DEBUG_NAMED("client", "HttpClient[%s]::handleProcessResponse() received response in %fms",
       debugName().c_str(), dur.toSec()*1000);
 
-    if (onResponse) {
-      auto copy = onResponse;
+    if (onResponse && alive) {
+      auto callback = onResponse;
       ScopedUnlock unlock(lock);
-      copy(req);
+      // Danger: if callback references HttpClient object then there is small chance
+      // this instance is destroyed right after lock is released.
+      callback(req);
     }
     req->processResponse();
     req->updateState(HttpRequest::State::Done);

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -71,6 +71,8 @@ struct HttpClient::Internal {
   int idleTimeoutMs = 0;
   int reconnectAttempts = 0;
 
+  /// Some internal ID of HTTP client.
+  /// It is used for writing more distinguishable debugName() in logs.
   int id = 0;
   /// A queue of requests.
   std::deque<std::shared_ptr<HttpRequest>> requests;
@@ -89,7 +91,8 @@ struct HttpClient::Internal {
   int remotePort = 0;
 
   /// Internal state.
-  State state = State::Invalid;
+  /// State was stored as a struct originally, but storing it as an atomic proved to be problematic.
+  std::atomic<State::State_t> state{State::Invalid};
 
   /// Number of bytes sent from current part (header or body).
   size_t data_sent = 0;
@@ -112,6 +115,8 @@ struct HttpClient::Internal {
   /// Mutex for processing socket state.
   std::mutex process_guard;
 
+  /// Counter for update cycles. It is incremented every time handleSocketEvents is called.
+  /// It helps debugging multiple FSM transitions.
   std::atomic_int updateCounter = 0;
 
   /// True if owning HttpClient is still alive.
@@ -142,7 +147,7 @@ struct HttpClient::Internal {
   }
 
   /// Get socket events for specified state.
-  int eventsForState(State state) const;
+  int eventsForState(State::State_t state) const;
 
   /// Does actual connection.
   /// @param I - reference to self/Internal. Used to keep instance alive.
@@ -265,12 +270,15 @@ void HttpClient::Internal::release(Lock& lock)
 
 void HttpClient::Internal::updateState(Lock& lock, State newState)
 {
-  if (newState == state)
-    return;
+  State oldState{State::Invalid};
+  {
+    if (newState == state)
+      return;
 
-  auto oldState = state;
-  state = newState;
-  cv.notify_all();
+    oldState = state.load();
+    state = newState;
+    cv.notify_all();
+  }
 
   std::shared_ptr<HttpRequest> activeReq;
   activeReq = active_request;
@@ -279,13 +287,13 @@ void HttpClient::Internal::updateState(Lock& lock, State newState)
       newState.toString(), oldState.toString(),
       updateCounter.load(), activeReq->id(), activeReq->elapsed().toSec());
   } else {
-    assert(!state.hasRequest());
+    assert(!State(state).hasRequest());
     LOCAL_DEBUG("HttpClient[%s]::updateState(%s) from %s at step=%d", debugName().c_str(),
       newState.toString(), oldState.toString(), updateCounter.load());
   }
 }
 
-int HttpClient::Internal::eventsForState(State s) const
+int HttpClient::Internal::eventsForState(State::State_t s) const
 {
   switch (s) {
     case State::Invalid:
@@ -351,7 +359,7 @@ bool HttpClient::Internal::pullNewTask(Lock& processLock)
 
 void HttpClient::Internal::handleDisconnect(Lock& lock, Error disconnectError)
 {
-  State stateCopy = state;
+  State stateCopy = state.load();
 
   if (socket && socket->valid()) {
     poll_set->setEvents(fd(), 0);
@@ -430,7 +438,7 @@ void HttpClient::setIdleTimeoutHandler(int timeoutMs, TimeoutHandler&& handler)
   internal_->idleTimeoutMs = timeoutMs;
 
   // If we're currently in Idle state and have a valid socket, set the timer
-  if (internal_->state == State::Idle && internal_->socket && internal_->poll_set && timeoutMs > 0) {
+  if (internal_->state.load() == State::Idle && internal_->socket && internal_->poll_set && timeoutMs > 0) {
     internal_->poll_set->setTimerEvent(internal_->socket->fd(), timeoutMs);
     LOCAL_INFO("HttpClient[%s]::setIdleTimeoutHandler: Set idle timeout timer to %d ms", internal_->debugName().c_str(), timeoutMs);
   }
@@ -540,13 +548,12 @@ HttpClient::State HttpClient::getState() const
 {
   if (!internal_)
     return State::Invalid;
-  Lock lock(internal_->process_guard, THIS_LOCATION);
-  return internal_->state;
+  return internal_->state.load();
 }
 
 bool HttpClient::isActive() const
 {
-  State s = getState();
+  State s = internal_->state.load();
   if (s == State::Invalid || s == State::Idle)
     return false;
   return true;
@@ -613,7 +620,7 @@ Error HttpClient::enqueueRequest(const std::shared_ptr<HttpRequest>& request)
 
   Lock lock2(internal_->process_guard, THIS_LOCATION);
   // If we're in Idle state and have a valid socket, trigger processing
-  if (internal_->state == State::Idle && internal_->socket && internal_->socket->valid()) {
+  if (internal_->state.load() == State::Idle && internal_->socket && internal_->socket->valid()) {
     if (internal_->pullNewTask(lock2)) {
       // There is some probability that the task we pulled is not the same task we have enqueued.
       // It can happen if several threads are enqueuing requests.
@@ -787,7 +794,7 @@ Error HttpClient::waitConnected(const WallDuration& duration)
   if (!internal_->socket || !internal_->socket->valid())
     return Error::InvalidHandle;
 
-  std::unique_lock lock(internal_->process_guard);
+  Lock lock(internal_->process_guard, THIS_LOCATION, 0.02);
   if (internal_->cv.wait_for(lock, std::chrono::duration<double>(duration.toSec()),
     [this]() {
       switch (internal_->state) {
@@ -815,15 +822,16 @@ int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFl
 
   // TODO: Disable it once most transport bugs are resolved.
   LOCAL_DEBUG("HttpClient[%s]::handleSocketEvents(%s) in state %s", I->debugName().c_str(),
-    PollSet::eventToString(evtFlags).c_str(), I->state.toString());
+    PollSet::eventToString(evtFlags).c_str(), State(I->state).toString());
 
   MINIROS_PROFILE_SCOPE2("HttpClient", "handleSocketEvents");
 
-  Lock lock(I->process_guard, THIS_LOCATION);
+  Lock lock(I->process_guard, THIS_LOCATION, 0.02);
   /// Keep a copy of itself.
   ++I->updateCounter;
-  State& state = I->state;
-  State initialState = state;
+
+  auto& state = I->state;
+  State initialState = state.load();
 
   // The following states are expected to fall through.
   // Each "handle" method can update internal state.
@@ -873,7 +881,7 @@ int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFl
         if (I->onIdleTimeout && I->socket) {
           auto callback = I->onIdleTimeout;
           auto socket = I->socket;
-          State stateCopy = state;
+          State stateCopy = state.load();
           ScopedUnlock unlock(lock);
           callback(socket, stateCopy);
         }
@@ -914,7 +922,7 @@ int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFl
     // Nothing to do here.
   } else if (stateChanges == 0 && state != State::Invalid) {
     std::string evt = PollSet::eventToString(evtFlags);
-    LOCAL_WARN("HttpClient unhandled events: %s in state %s", evt.c_str(), state.toString());
+    LOCAL_WARN("HttpClient unhandled events: %s in state %s", evt.c_str(), State(state).toString());
   }
 
   if (state == State::Idle && initialState != State::Idle && I->idleTimeoutMs > 0) {

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -19,6 +19,10 @@
 #include "io/poll_set.h"
 #include "network/net_adapter.h"
 
+namespace {
+std::atomic_int32_t g_lastClientId{0};
+}
+
 namespace miniros {
 namespace http {
 
@@ -67,6 +71,7 @@ struct HttpClient::Internal {
   int idleTimeoutMs = 0;
   int reconnectAttempts = 0;
 
+  int id = 0;
   /// A queue of requests.
   std::deque<std::shared_ptr<HttpRequest>> requests;
 
@@ -118,6 +123,7 @@ struct HttpClient::Internal {
 
   Internal(PollSet* ps) : poll_set(ps)
   {
+    id = ++g_lastClientId;
     assert(ps);
   }
 
@@ -184,7 +190,7 @@ struct HttpClient::Internal {
   /// Get name for debug output.
   std::string debugName() const
   {
-    return address.lstr() + std::string(" fd=") + std::to_string(fd());
+    return std::to_string(id) + "@" + address.lstr() + std::string(" fd=") + std::to_string(fd());
   }
 
   void updateState(Lock& lock, State newState);
@@ -207,15 +213,22 @@ struct HttpClient::Internal {
       num++;
     return num;
   }
+
+  void detachFromPollSet()
+  {
+    if (socket && poll_set && poll_registered) {
+      [[maybe_unused]] bool ret = poll_set->delSocket(socket->fd());
+      assert(ret);
+      poll_registered = false;
+    }
+  }
 };
 
 void HttpClient::Internal::release(Lock& lock)
 {
   LOCAL_DEBUG("HttpClient::Internal[%d]::release()", fd());
-  if (socket && poll_set && poll_registered) {
-    poll_set->delSocket(socket->fd());
-    poll_registered = false;
-  }
+
+  detachFromPollSet();
 
   onConnect = {};
   onDisconnect = {};
@@ -343,7 +356,7 @@ void HttpClient::Internal::handleDisconnect(Lock& lock, Error disconnectError)
   if (socket && socket->valid()) {
     poll_set->setEvents(fd(), 0);
   }
-  updateState(lock, State::Disconnected);
+
   // Push active request back to queue.
   if (active_request) {
     std::unique_lock reqLock(requests_guard);
@@ -367,9 +380,8 @@ void HttpClient::Internal::handleDisconnect(Lock& lock, Error disconnectError)
     }
   }
 
-  LOCAL_INFO("HttpClient[%s]::handleDisconnect() - connection is closed from state %s", debugName().c_str(), stateCopy.toString());
-
   if (onDisconnect && alive) {
+    LOCAL_INFO("HttpClient[%s]::handleDisconnect() - connection is closed from state %s, err=%s, invoking callback", debugName().c_str(), stateCopy.toString(), disconnectError.toString());
     // Copying all mutable data, which can be changed during callback.
     auto callback = onDisconnect;
     auto socketCopy = socket;
@@ -377,7 +389,10 @@ void HttpClient::Internal::handleDisconnect(Lock& lock, Error disconnectError)
     // Danger: if callback references HttpClient object then there is small chance
     // this instance is destroyed right after lock is released.
     callback(socketCopy, stateCopy, disconnectError);
+  } else {
+    LOCAL_INFO("HttpClient[%s]::handleDisconnect() - connection is closed from state %s, err=%s, no callback", debugName().c_str(), stateCopy.toString(), disconnectError.toString());
   }
+
 }
 
 void HttpClient::setDisconnectHandler(DisconnectHandler&& handler)
@@ -447,19 +462,23 @@ Error HttpClient::reconnect(int timeoutMs)
 
   internal_->reconnectAttempts++;
 
-  if (timeoutMs > 0) {
-    // Really expect socket to exist, even in some placeholder form.
-    assert(internal_->socket && internal_->socket->valid());
-    if (!internal_->socket || !internal_->socket->valid()) {
-      return Error::InvalidHandle;
-    }
-    internal_->updateState(lock, needAddress ? State::WaitingAddress : State::WaitReconnect);
-    internal_->poll_set->setTimerEvent(internal_->socket->fd(), timeoutMs);
-    return Error::Ok;
+  if (timeoutMs <= 0) {
+    // Immediate connection.
+    return internal_->connectImpl(internal_, lock, newAddress);
   }
 
-  // Immediate connection.
-  return internal_->connectImpl(internal_, lock, newAddress);
+  // Schedule reconnect by timer event from PollSet.
+  assert(internal_->socket && internal_->socket->valid());
+  if (!internal_->socket || !internal_->socket->valid()) {
+    return Error::InvalidHandle;
+  }
+  internal_->updateState(lock, needAddress ? State::WaitingAddress : State::WaitReconnect);
+  auto ret = internal_->poll_set->setTimerEvent(internal_->socket->fd(), timeoutMs);
+  assert(ret);
+  if (!ret) {
+    LOCAL_WARN("HttpClient[%s]::reconnect() - failed to set timer event", internal_->debugName().c_str());
+  }
+  return Error::Ok;
 }
 
 Error HttpClient::Internal::readResponse()
@@ -708,16 +727,17 @@ Error HttpClient::Internal::connectImpl(const std::shared_ptr<Internal>& I, Lock
     return Error::InternalError;
   }
 
-  if (!socket) {
+  if (socket) {
+    // Need to close socket since its state after failed 'connect' is undefined.
+    detachFromPollSet();
+    socket->close();
+  } else {
     socket.reset(new NetSocket());
-    socket->setKeepAlive(true);
-  } else if (socket->valid()) {
-    socket->disconnect();
-    // Socket's FD can be changed during tcpConnect, so we must detach it from poll_set and reattach after we initiate connection.
-    poll_set->delSocket(socket->fd());
-    poll_registered = false;
   }
 
+  LOCAL_WARN("HttpClient[%s]::connectImpl initiating connection to %s:%d", debugName().c_str(), address.address.c_str(), address.port());
+
+  socket->setKeepAlive(true);
   Error err = socket->tcpConnect(newAddress, true);
 
   // Store host and port for:
@@ -732,13 +752,14 @@ Error HttpClient::Internal::connectImpl(const std::shared_ptr<Internal>& I, Lock
     connected = true;
   } else {
     // Failed to initialize connection.
-    LOCAL_WARN("HttpClient::connect failed to initialize connection to %s:%d", address.address.c_str(), address.port());
+    LOCAL_WARN("HttpClient[%s]::connect failed to initialize connection to %s:%d", debugName().c_str(), address.address.c_str(), address.port());
     return err;
   }
 
   updateState(lock, connected ? State::Idle : State::Connecting);
 
-  initSocketEvents(I, lock);
+  bool ret = initSocketEvents(I, lock);
+  assert(ret);
 
   return Error::Ok;
 }
@@ -753,7 +774,7 @@ bool HttpClient::Internal::initSocketEvents(const std::shared_ptr<Internal>& I, 
         if (ptr)
           return handleSocketEvents(ptr, event);
         return 0;
-      }, I, THIS_LOCATION);
+      }, {}, THIS_LOCATION);
   return poll_registered;
 }
 
@@ -952,7 +973,7 @@ void HttpClient::Internal::handleConnecting(Lock& lock, int evtFlags)
       return;
 
     if (err == Error::Ok) {
-      MINIROS_DEBUG_NAMED("client", "HttpClient[%s]::handleEvents(state=Connecting) - connected", debugName().c_str());
+      MINIROS_DEBUG("HttpClient[%s]::handleEvents(state=Connecting) - connected", debugName().c_str());
       // Connection is complete.
       // Attempt to pull requests will be done in "handleSocketEvents" method.
       reconnectAttempts = 0;
@@ -1004,7 +1025,7 @@ void HttpClient::Internal::handleWriteRequest(Lock& lock, int evtFlags, bool fal
     if (written > 0) {
       data_sent += written;
       double dur = (SteadyTime::now() - active_request->getRequestStart()).toSec() * 1000;
-      MINIROS_DEBUG_NAMED("client", "HttpClient[%s]::handleWriteRequest() HttpClient written %d/%d bytes of header, t=%fms",
+      MINIROS_DEBUG("HttpClient[%s]::handleWriteRequest() HttpClient written %d/%d bytes of header, t=%fms",
         debugName().c_str(), static_cast<int>(written), static_cast<int>(totalSize), dur);
     }
 

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -404,7 +404,6 @@ void HttpClient::Internal::handleDisconnect(Lock& lock, Error disconnectError)
   } else {
     LOCAL_INFO("HttpClient[%s]::handleDisconnect() - connection is closed from state %s, err=%s, no callback", debugName().c_str(), stateCopy.toString(), disconnectError.toString());
   }
-
 }
 
 void HttpClient::setDisconnectHandler(DisconnectHandler&& handler)
@@ -778,13 +777,15 @@ Error HttpClient::Internal::connectImpl(const std::shared_ptr<Internal>& I, Lock
 
 bool HttpClient::Internal::initSocketEvents(const std::shared_ptr<Internal>& I, Lock& /*lock*/)
 {
-  const int events = eventsForState(state) | PollSet::EventUpdate;
+  const int events = eventsForState(state);
   poll_registered = poll_set->addSocket(socket->fd(), events,
     [wptr = std::weak_ptr(I)](int event)
       {
-        if (auto ptr = wptr.lock())
-          return handleSocketEvents(ptr, event);
-        LOCAL_WARN("HttpClient::handleSocketEvents() - call for destroyed client instance");
+        if (auto ptr = wptr.lock()) {
+          handleSocketEvents(ptr, event);
+          return 0;
+        }
+        LOCAL_WARN("HttpClient[?]::handleSocketEvents() - call for destroyed client instance");
         return 0;
       }, {}, THIS_LOCATION);
   return poll_registered;
@@ -820,11 +821,10 @@ Error HttpClient::waitConnected(const WallDuration& duration)
   return Error::Timeout;
 }
 
-int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFlags)
+void HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFlags)
 {
   if (!I) {
     LOCAL_ERROR("HttpClient::handleSocketEvents() - invalid pointer to internal");
-    return 0;
   }
 
   MINIROS_PROFILE_SCOPE2("HttpClient", "handleSocketEvents");
@@ -932,14 +932,19 @@ int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFl
     LOCAL_WARN("HttpClient unhandled events: %s in state %s", evt.c_str(), State(state).toString());
   }
 
-  if (state == State::Idle && initialState != State::Idle && I->idleTimeoutMs > 0) {
-    I->poll_set->setTimerEvent(I->socket->fd(), I->idleTimeoutMs);
-  }
+  // Update event flags.
+  // Socket can be destroyed in disconnect handler.
+  if (I->socket && I->socket->valid()) {
+    int fd = I->socket->fd();
+    if (state == State::Idle && initialState != State::Idle && I->idleTimeoutMs > 0) {
+      I->poll_set->setTimerEvent(fd, I->idleTimeoutMs);
+    }
 
-  int newEvt = I->eventsForState(state);
-  LOCAL_DEBUG("HttpClient::handleSocketEvents() exit in state %s new evt=%s", State(state).toString(),
-    PollSet::eventToString(newEvt).c_str());
-  return newEvt;
+    int newEvt = I->eventsForState(state);
+    LOCAL_DEBUG("HttpClient::handleSocketEvents() exit in state %s new evt=%s", State(state).toString(),
+      PollSet::eventToString(newEvt).c_str());
+    I->poll_set->setEvents(fd, newEvt);
+  }
 }
 
 void HttpClient::Internal::handleWaitAddress(const std::shared_ptr<Internal>& I, Lock& lock, int events)

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -181,10 +181,10 @@ struct HttpClient::Internal {
   ///    - Idle if no requests.
   void handleProcessResponse(Lock& lock);
 
-  /// Get name for debug otput
+  /// Get name for debug output.
   std::string debugName() const
   {
-    return address.str() + std::string(" fd=") + std::to_string(fd());
+    return address.lstr() + std::string(" fd=") + std::to_string(fd());
   }
 
   void updateState(Lock& lock, State newState);

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <memory>
 
+/// This log channel maps to miniros.http
 #define MINIROS_PACKAGE_NAME "http"
 
 #include "miniros/console.h"
@@ -302,6 +303,8 @@ int HttpClient::Internal::eventsForState(State::State_t s) const
       return PollSet::EventOut;
     case State::WaitReconnect:
       return 0;
+    case State::WaitingAddress:
+      return 0;
     case State::Idle:
       return 0;
     case State::WriteRequest:
@@ -315,6 +318,7 @@ int HttpClient::Internal::eventsForState(State::State_t s) const
     default:
       return 0;
   }
+  LOCAL_ERROR("HttpClient::eventsForState(%s) - unhandled state", State(s).toString());
   return 0;
 }
 
@@ -630,9 +634,11 @@ Error HttpClient::enqueueRequest(const std::shared_ptr<HttpRequest>& request)
       internal_->handleWriteRequest(lock2, 0, true);
 
       if (!internal_->poll_set->setEvents(internal_->socket->fd(), internal_->eventsForState(internal_->state))) {
-        LOCAL_ERROR("HttpClient(%d) Failed to update poll set to enable events to send request", internal_->fd());
+        LOCAL_ERROR("HttpClient(%s)::enqueueRequest failed to update poll set to enable events to send request", internal_->debugName().c_str());
       }
       immediate = true;
+    } else {
+      LOCAL_ERROR("HttpClient(%s)::enqueueRequest failed to update poll set to enable events to send request", internal_->debugName().c_str());
     }
   }
 
@@ -742,10 +748,9 @@ Error HttpClient::Internal::connectImpl(const std::shared_ptr<Internal>& I, Lock
     socket.reset(new NetSocket());
   }
 
-  LOCAL_WARN("HttpClient[%s]::connectImpl initiating connection to %s:%d", debugName().c_str(), address.address.c_str(), address.port());
-
-  socket->setKeepAlive(true);
   Error err = socket->tcpConnect(newAddress, true);
+
+  LOCAL_WARN("HttpClient[%s]::connectImpl initiating connection to %s:%d", debugName().c_str(), address.address.c_str(), address.port());
 
   // Store host and port for:
   // 1. Reconnect.
@@ -762,7 +767,7 @@ Error HttpClient::Internal::connectImpl(const std::shared_ptr<Internal>& I, Lock
     LOCAL_WARN("HttpClient[%s]::connect failed to initialize connection to %s:%d", debugName().c_str(), address.address.c_str(), address.port());
     return err;
   }
-
+  socket->setKeepAlive(true);
   updateState(lock, connected ? State::Idle : State::Connecting);
 
   bool ret = initSocketEvents(I, lock);
@@ -777,9 +782,9 @@ bool HttpClient::Internal::initSocketEvents(const std::shared_ptr<Internal>& I, 
   poll_registered = poll_set->addSocket(socket->fd(), events,
     [wptr = std::weak_ptr(I)](int event)
       {
-        auto ptr = wptr.lock();
-        if (ptr)
+        if (auto ptr = wptr.lock())
           return handleSocketEvents(ptr, event);
+        LOCAL_WARN("HttpClient::handleSocketEvents() - call for destroyed client instance");
         return 0;
       }, {}, THIS_LOCATION);
   return poll_registered;
@@ -817,16 +822,18 @@ Error HttpClient::waitConnected(const WallDuration& duration)
 
 int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFlags)
 {
-  if (!I)
+  if (!I) {
+    LOCAL_ERROR("HttpClient::handleSocketEvents() - invalid pointer to internal");
     return 0;
-
-  // TODO: Disable it once most transport bugs are resolved.
-  LOCAL_DEBUG("HttpClient[%s]::handleSocketEvents(%s) in state %s", I->debugName().c_str(),
-    PollSet::eventToString(evtFlags).c_str(), State(I->state).toString());
+  }
 
   MINIROS_PROFILE_SCOPE2("HttpClient", "handleSocketEvents");
 
   Lock lock(I->process_guard, THIS_LOCATION, 0.02);
+
+  LOCAL_DEBUG("HttpClient[%s]::handleSocketEvents(%s) in state %s", I->debugName().c_str(),
+    PollSet::eventToString(evtFlags).c_str(), State(I->state).toString());
+
   /// Keep a copy of itself.
   ++I->updateCounter;
 
@@ -929,7 +936,10 @@ int HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtFl
     I->poll_set->setTimerEvent(I->socket->fd(), I->idleTimeoutMs);
   }
 
-  return I->eventsForState(I->state);
+  int newEvt = I->eventsForState(state);
+  LOCAL_DEBUG("HttpClient::handleSocketEvents() exit in state %s new evt=%s", State(state).toString(),
+    PollSet::eventToString(newEvt).c_str());
+  return newEvt;
 }
 
 void HttpClient::Internal::handleWaitAddress(const std::shared_ptr<Internal>& I, Lock& lock, int events)

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -17,28 +17,18 @@
 #include "internal/scoped_locks.h"
 #include "miniros/http/http_server_connection.h"
 #include "miniros/callback_queue.h"
+#include "miniros/http/endpoint_collection.h"
 
 namespace miniros {
 namespace http {
-
-struct Binding {
-  std::unique_ptr<EndpointFilter> filter;
-  std::shared_ptr<EndpointHandler> endpoint;
-  CallbackQueuePtr callbackQueue;
-
-  Binding(std::unique_ptr<EndpointFilter>&& filter, const std::shared_ptr<EndpointHandler>& endpoint, const CallbackQueuePtr& cb)
-    : filter(std::move(filter)), endpoint(endpoint), callbackQueue(cb)
-  {}
-};
 
 struct HttpServer::Internal {
   using Lock = std::unique_lock<Lifetime<HttpServer>>;
 
   CloseConnectionHandler onCloseConnection;
-  /// A collection of endpoints.
-  std::vector<Binding> endpoints;
-  /// A mutex for endpoints.
-  std::mutex endpointsGuard;
+
+  /// Thread safe collection of endpoints.
+  std::shared_ptr<internal::EndpointCollection> endpoints;
 
   /// Active connections.
   std::map<int, std::shared_ptr<HttpServerConnection>> connections;
@@ -58,6 +48,7 @@ struct HttpServer::Internal {
   Internal(PollSet* ps) : pollSet(ps)
   {
     assert(pollSet);
+    endpoints = std::make_shared<internal::EndpointCollection>();
   }
 
   ~Internal()
@@ -207,6 +198,12 @@ PollSet* HttpServer::getPollSet() const
   return internal_ ? internal_->pollSet : nullptr;
 }
 
+std::shared_ptr<HttpServerConnection> HttpServer::makeConnection(const std::shared_ptr<network::NetSocket>& socket)
+{
+  return std::make_shared<HttpServerConnection>(this, socket, internal_->pollSet);
+}
+
+
 void HttpServer::acceptClient(const std::shared_ptr<Lifetime<HttpServer>>& lifetime, network::NetSocket* sock)
 {
   // This callback is called from PollSet thread.
@@ -219,22 +216,24 @@ void HttpServer::acceptClient(const std::shared_ptr<Lifetime<HttpServer>>& lifet
   if (!sock)
     return;
 
-  auto [client, err] = sock->accept();
+  auto [clientSock, err] = sock->accept();
 
-  if (!client) {
+  if (!clientSock) {
     MINIROS_ERROR("HttpServer::accept() - failed to accept client: %s", err.toString());
     return;
   }
 
-  int fd = client->fd();
-  MINIROS_DEBUG("HttpServer::accept() - accepting new client fd=%d", client->fd());
+  int fd = clientSock->fd();
+  MINIROS_DEBUG("HttpServer::accept() - accepting new client fd=%d", clientSock->fd());
 
-  client->setNonBlock();
-  client->setNoDelay(true);
+  clientSock->setNonBlock();
+  clientSock->setNoDelay(true);
 
   assert(internal_->pollSet);
 
-  std::shared_ptr<HttpServerConnection> connection(new HttpServerConnection(this, client, internal_->pollSet));
+  std::shared_ptr<HttpServerConnection> connection = makeConnection(clientSock);
+  connection->setEndpointCollection(internal_->endpoints);
+
   internal_->connections[fd] = connection;
   auto internalCopy = internal_->lifetime;
 
@@ -261,26 +260,18 @@ void HttpServer::acceptClient(const std::shared_ptr<Lifetime<HttpServer>>& lifet
 
 Error HttpServer::registerEndpoint(std::unique_ptr<EndpointFilter>&& filter, const std::shared_ptr<EndpointHandler>& handler, const CallbackQueuePtr& cb)
 {
-  if (!internal_)
+  if (!internal_ || !internal_->endpoints)
     return Error::InternalError;
 
-
-  std::unique_lock<std::mutex> lock(internal_->endpointsGuard);
-  internal_->endpoints.emplace_back(std::move(filter), handler, cb);
-  return Error::Ok;
+  return internal_->endpoints->registerEndpoint(std::move(filter), handler, cb);
 }
 
 std::pair<std::shared_ptr<EndpointHandler>, std::shared_ptr<CallbackQueue>> HttpServer::findEndpoint(const HttpParserFrame& frame)
 {
-  std::unique_lock<std::mutex> lock(internal_->endpointsGuard);
+  if (!internal_ || !internal_->endpoints)
+    return {};
 
-  for (const Binding& binding: internal_->endpoints) {
-    if (binding.filter->check(frame)) {
-      return {binding.endpoint, binding.callbackQueue};
-    }
-  }
-
-  return {};
+  return internal_->endpoints->findEndpoint(frame);
 }
 
 }

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -24,7 +24,10 @@ namespace miniros {
 namespace http {
 
 struct HttpServer::Internal {
-  using Lock = std::unique_lock<Lifetime<HttpServer>>;
+  using Lock = Lifetime<HttpServer>::Lock;
+
+  /// Owner.
+  HttpServer* server = nullptr;
 
   CloseConnectionHandler onCloseConnection;
 
@@ -49,7 +52,7 @@ struct HttpServer::Internal {
   /// Global mutex.
   std::shared_ptr<Lifetime<HttpServer>> lifetime;
 
-  Internal(HttpServer* server, PollSet* ps) : pollSet(ps)
+  Internal(HttpServer* server, PollSet* ps) : server(server), pollSet(ps)
   {
     assert(pollSet);
     endpoints = std::make_shared<internal::EndpointCollection>();
@@ -61,14 +64,99 @@ struct HttpServer::Internal {
     MINIROS_DEBUG("HttpServer::~Internal()");
   }
 
-  void closeConnection(Lock& lock, const std::shared_ptr<HttpServerConnection>& connection, const std::string& reason);
+  void onConnectionClosed(Lock& lock, const std::shared_ptr<HttpServerConnection>& connection, const std::string& reason);
+
+  Error start(network::NetSocket& socket, network::NetAddress::Type addrType, int port);
+
+  /// Accept client and add it to event processing.
+  /// For internal usage only.
+  /// @param lock - acquired lock on internal mutex.
+  /// @param sock - listening socket.
+  void acceptClient(Lock& lock, network::NetSocket* sock);
 };
 
-void HttpServer::Internal::closeConnection(Lock& lock, const std::shared_ptr<HttpServerConnection>& connection,
+Error HttpServer::Internal::start(network::NetSocket& socket, network::NetAddress::Type addrType, int port)
+{
+  std::unique_lock lock(*lifetime);
+  if (Error err = socket.tcpListen(port, network::NetAddress::AddressIPv4, 100); !err) {
+    return err;
+  }
+
+  if (Error err = socket.setNonBlock(); !err) {
+    return err;
+  }
+
+  int fd = socket.fd();
+  std::weak_ptr weakLifetime = lifetime;
+
+  bool added = pollSet->addSocket(fd, PollSet::EventIn,
+    [this, weakLifetime, &socket](int flags)
+    {
+      auto l = weakLifetime.lock();
+      if (!l)
+        return 0;
+      // This callback is called from PollSet thread.
+      // Check if server instance is still alive and usable.
+      auto lock = l->getLock();
+      if (!l->valid(lock))
+        return 0;
+
+      if (flags & PollSet::EventIn) {
+        this->acceptClient(lock, &socket);
+      } else {
+        MINIROS_WARN("HttpServer socket: unexpected event %d", flags);
+      }
+      return 0;
+    }, lifetime, THIS_LOCATION);
+
+  if (!added)
+  {
+    MINIROS_ERROR("Failed to register listening socket");
+    return Error::InternalError;
+  }
+
+  MINIROS_INFO("HttpServer::start() created HTTP server, fd=%d", fd);
+  return Error::Ok;
+}
+
+void HttpServer::Internal::acceptClient(Lock& /*lock*/, network::NetSocket* sock)
+{
+  if (!sock)
+    return;
+
+  if (stoppingListeners)
+    return;
+
+  if (!server)
+    return;
+  int listenFd = sock->fd();
+  auto [clientSock, err] = sock->accept();
+
+  if (!clientSock) {
+    MINIROS_ERROR("HttpServer[%d]::accept() - failed to accept client: %s", listenFd, err.toString());
+    return;
+  }
+
+  MINIROS_DEBUG("HttpServer[%d]::accept() - accepting new client fd=%d", listenFd, clientSock->fd());
+
+  clientSock->setNonBlock();
+  clientSock->setNoDelay(true);
+
+  assert(pollSet);
+
+  std::shared_ptr<HttpServerConnection> connection = server->makeConnection(clientSock);
+  connection->setEndpointCollection(endpoints);
+  connections.insert(connection);
+
+  // Connection object will start receiving events from external thread.
+  connection->attachPollSet(pollSet);
+}
+
+void HttpServer::Internal::onConnectionClosed(Lock& lock, const std::shared_ptr<HttpServerConnection>& connection,
   const std::string& reason)
 {
   int fd = connection->fd();
-  MINIROS_INFO("HttpServer::closeConnection() fd=%d: %s", fd, reason.c_str());
+  MINIROS_INFO("HttpServer::onConnectionClosed() fd=%d: %s", fd, reason.c_str());
 
   auto it = connections.find(connection);
   if (it == connections.end())
@@ -91,8 +179,8 @@ void HttpServer::onConnectionClosed(const std::shared_ptr<HttpServerConnection>&
   assert(internal_);
   if (!internal_)
     return;
-  std::unique_lock lock(*internal_->lifetime);
-  internal_->closeConnection(lock, connection, reason);
+  auto lock = internal_->lifetime->getLock();
+  internal_->onConnectionClosed(lock, connection, reason);
 }
 
 HttpServer::HttpServer(PollSet* pollSet)
@@ -112,6 +200,7 @@ HttpServer::~HttpServer()
     auto lock = lifetime->getLock();
     internal_->lifetime->reset(lock);
     internal_->pollSet = nullptr;
+    internal_->server = nullptr;
     internal_.reset();
   }
   MINIROS_DEBUG("HttpServer::~HttpServer()");
@@ -122,38 +211,15 @@ Error HttpServer::start(int port)
   if (!internal_)
     return Error::InternalError;
 
-  std::unique_lock lock(*internal_->lifetime);
-  if (Error err = internal_->socket_v4.tcpListen(port, network::NetAddress::AddressIPv4, 100); !err) {
-    return err;
-  }
+  return internal_->start(internal_->socket_v4, network::NetAddress::AddressIPv4, port);
+}
 
-  if (Error err = internal_->socket_v4.setNonBlock(); !err) {
-    return err;
-  }
-
-  int fd = internal_->socket_v4.fd();
-  auto lifetime = internal_->lifetime;
-
-  bool added = internal_->pollSet->addSocket(fd, PollSet::EventIn,
-    [this, lifetime](int flags)
-    {
-      if (flags & PollSet::EventIn) {
-        this->acceptClient(lifetime, &internal_->socket_v4);
-      } else {
-        MINIROS_WARN("HttpServer socket: unexpected event %d", flags);
-      }
-      return 0;
-    }, lifetime, THIS_LOCATION);
-
-  if (!added)
-  {
-    MINIROS_ERROR("Failed to register listening socket");
+Error HttpServer::start6(int port)
+{
+  if (!internal_)
     return Error::InternalError;
-  }
 
-  MINIROS_INFO("HttpServer::start() created HTTP ipv4 server, fd=%d", fd);
-  // TODO: ipv6 listener.
-  return Error::Ok;
+  return internal_->start(internal_->socket_v6, network::NetAddress::AddressIPv6, port);
 }
 
 Error HttpServer::stop()
@@ -207,44 +273,6 @@ PollSet* HttpServer::getPollSet() const
 std::shared_ptr<HttpServerConnection> HttpServer::makeConnection(const std::shared_ptr<network::NetSocket>& socket)
 {
   return std::make_shared<HttpServerConnection>(internal_->lifetime, socket);
-}
-
-void HttpServer::acceptClient(const std::shared_ptr<Lifetime<HttpServer>>& lifetime, network::NetSocket* sock)
-{
-  if (!sock)
-    return;
-
-  // This callback is called from PollSet thread.
-  // Check if server instance is still alive and usable.
-  auto lock = lifetime->getLock();
-  if (!lifetime->valid(lock))
-    return;
-
-  if (!internal_)
-    return;
-
-  if (internal_->stoppingListeners)
-    return;
-
-  auto [clientSock, err] = sock->accept();
-
-  if (!clientSock) {
-    MINIROS_ERROR("HttpServer::accept() - failed to accept client: %s", err.toString());
-    return;
-  }
-
-  MINIROS_DEBUG("HttpServer::accept() - accepting new client fd=%d", clientSock->fd());
-
-  clientSock->setNonBlock();
-  clientSock->setNoDelay(true);
-
-  assert(internal_->pollSet);
-
-  std::shared_ptr<HttpServerConnection> connection = makeConnection(clientSock);
-  connection->setEndpointCollection(internal_->endpoints);
-  internal_->connections.insert(connection);
-  // Connection object will start receiving events from external thread.
-  connection->attachPollSet(internal_->pollSet);
 }
 
 Error HttpServer::registerEndpoint(std::unique_ptr<EndpointFilter>&& filter, const std::shared_ptr<EndpointHandler>& handler, const CallbackQueuePtr& cb)

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -78,7 +78,7 @@ struct HttpServer::Internal {
 Error HttpServer::Internal::start(network::NetSocket& socket, network::NetAddress::Type addrType, int port)
 {
   std::unique_lock lock(*lifetime);
-  if (Error err = socket.tcpListen(port, network::NetAddress::AddressIPv4, 100); !err) {
+  if (Error err = socket.tcpListen(port, addrType, 100); !err) {
     return err;
   }
 
@@ -228,27 +228,37 @@ Error HttpServer::stop()
     return Error::InternalError;
 
   std::set<std::shared_ptr<HttpServerConnection>> connectionsCopy;
-  int listenFd = MINIROS_INVALID_SOCKET;
 
   {
     std::unique_lock lock(*internal_->lifetime);
 
-    if (internal_->pollSet && internal_->socket_v4.valid()) {
-      listenFd = internal_->socket_v4.fd();
-      LOCAL_INFO("HttpServer[%d]::stop() - stopping listener socket", listenFd);
-      if (!internal_->pollSet->delSocket(internal_->socket_v4.fd())) {
-        return Error::InternalError;
+    if (internal_->pollSet) {
+      if (internal_->socket_v4.valid()) {
+        int fd = internal_->socket_v4.fd();
+        LOCAL_INFO("HttpServer::stop() - stopping ipv4 listener socket %d", fd);
+        if (!internal_->pollSet->delSocket(fd)) {
+          LOCAL_WARN("HttpServer::stop() - failed to detach ipv4 socket from PollSet");
+        }
+      }
+
+      if (internal_->socket_v6.valid()) {
+        int fd = internal_->socket_v6.fd();
+        LOCAL_INFO("HttpServer::stop() - stopping ipv6 listener socket %d", fd);
+        if (!internal_->pollSet->delSocket(fd)) {
+          LOCAL_WARN("HttpServer::stop() - failed to detach ipv6 socket from PollSet");
+        }
       }
     }
 
     internal_->socket_v4.close();
+    internal_->socket_v6.close();
 
     std::swap(connectionsCopy, internal_->connections);
   }
 
   for (auto connection: connectionsCopy) {
     int fd = connection->fd();
-    LOCAL_INFO("HttpServer[%d]::stop() - dropping connection %d", listenFd, fd);
+    LOCAL_INFO("HttpServer[]::stop() - dropping connection %d", fd);
     connection->detachFromServer(true);
   }
 

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -15,9 +15,10 @@
 #include "miniros/http/http_server.h"
 
 #include "internal/scoped_locks.h"
-#include "miniros/http/http_server_connection.h"
+#include "io/io.h"
 #include "miniros/callback_queue.h"
 #include "miniros/http/endpoint_collection.h"
+#include "miniros/http/http_server_connection.h"
 
 namespace miniros {
 namespace http {
@@ -31,7 +32,7 @@ struct HttpServer::Internal {
   std::shared_ptr<internal::EndpointCollection> endpoints;
 
   /// Active connections.
-  std::map<int, std::shared_ptr<HttpServerConnection>> connections;
+  std::set<std::shared_ptr<HttpServerConnection>> connections;
 
   /// Socket for accepting HTTP connections.
   network::NetSocket socket_v4;
@@ -39,16 +40,20 @@ struct HttpServer::Internal {
   /// IPv6 socket.
   network::NetSocket socket_v6;
 
+  /// Flag indicates that server is stopping and all incoming clients should be rejected.
+  volatile bool stoppingListeners = false;
+
   /// Poller to handle events.
   PollSet* pollSet;
 
   /// Global mutex.
-  std::shared_ptr<Lifetime<HttpServer>> lifetime = std::make_shared<Lifetime<HttpServer>>();
+  std::shared_ptr<Lifetime<HttpServer>> lifetime;
 
-  Internal(PollSet* ps) : pollSet(ps)
+  Internal(HttpServer* server, PollSet* ps) : pollSet(ps)
   {
     assert(pollSet);
     endpoints = std::make_shared<internal::EndpointCollection>();
+    lifetime = std::make_shared<Lifetime<HttpServer>>(server);
   }
 
   ~Internal()
@@ -56,30 +61,23 @@ struct HttpServer::Internal {
     MINIROS_DEBUG("HttpServer::~Internal()");
   }
 
-  void closeConnection(Lock& lock, int fd, const std::string& reason);
+  void closeConnection(Lock& lock, const std::shared_ptr<HttpServerConnection>& connection, const std::string& reason);
 };
 
-void HttpServer::Internal::closeConnection(Lock& lock, int fd, const std::string& reason)
+void HttpServer::Internal::closeConnection(Lock& lock, const std::shared_ptr<HttpServerConnection>& connection,
+  const std::string& reason)
 {
+  int fd = connection->fd();
   MINIROS_INFO("HttpServer::closeConnection() fd=%d: %s", fd, reason.c_str());
-  std::shared_ptr<HttpServerConnection> connection;
-  // TODO: Connection can close and unsubscribe itself.
-  // TODO: Still need to notify external users with onCloseConnection.
-  auto it = connections.find(fd);
-  if (it != connections.end()) {
-    if (pollSet) {
-      pollSet->delSocket(fd);
-    }
-    connection = it->second;
-    connection->detach();
-    connections.erase(fd);
-    connection->close();
 
-    if (onCloseConnection) {
-      auto handler = onCloseConnection;
-      ScopedUnlock unlock(lock);
-      handler(connection, reason);
-    }
+  auto it = connections.find(connection);
+  if (it == connections.end())
+    return;
+  connections.erase(connection);
+  if (onCloseConnection) {
+    auto handler = onCloseConnection;
+    ScopedUnlock unlock(lock);
+    handler(connection, reason);
   }
 }
 
@@ -88,19 +86,19 @@ void HttpServer::setCloseConnectionHandler(CloseConnectionHandler&& handler)
   internal_->onCloseConnection = std::move(handler);
 }
 
-void HttpServer::closeConnection(int fd, const std::string& reason)
+void HttpServer::onConnectionClosed(const std::shared_ptr<HttpServerConnection>& connection, const std::string& reason)
 {
   assert(internal_);
   if (!internal_)
     return;
   std::unique_lock lock(*internal_->lifetime);
-  internal_->closeConnection(lock, fd, reason);
+  internal_->closeConnection(lock, connection, reason);
 }
 
 HttpServer::HttpServer(PollSet* pollSet)
 {
   assert(pollSet);
-  internal_ = std::make_unique<Internal>(pollSet);
+  internal_ = std::make_unique<Internal>(this, pollSet);
 }
 
 HttpServer::~HttpServer()
@@ -111,8 +109,8 @@ HttpServer::~HttpServer()
     // 1. Close all connections.
     // 2. Detach all endpoints.
     stop();
-    std::unique_lock lock(*lifetime);
-    internal_->lifetime->alive = false;
+    auto lock = lifetime->getLock();
+    internal_->lifetime->reset(lock);
     internal_->pollSet = nullptr;
     internal_.reset();
   }
@@ -163,23 +161,31 @@ Error HttpServer::stop()
   if (!internal_)
     return Error::InternalError;
 
-  std::unique_lock lock(*internal_->lifetime);
+  std::set<std::shared_ptr<HttpServerConnection>> connectionsCopy;
+  int listenFd = MINIROS_INVALID_SOCKET;
 
-  int fd = 0;
-  if (internal_->pollSet && internal_->socket_v4.valid()) {
-    fd = internal_->socket_v4.fd();
-    LOCAL_INFO("HttpServer[%d]::stop() - stopping listener socket", fd);
-    if (!internal_->pollSet->delSocket(internal_->socket_v4.fd())) {
-      return Error::InternalError;
+  {
+    std::unique_lock lock(*internal_->lifetime);
+
+    if (internal_->pollSet && internal_->socket_v4.valid()) {
+      listenFd = internal_->socket_v4.fd();
+      LOCAL_INFO("HttpServer[%d]::stop() - stopping listener socket", listenFd);
+      if (!internal_->pollSet->delSocket(internal_->socket_v4.fd())) {
+        return Error::InternalError;
+      }
     }
+
+    internal_->socket_v4.close();
+
+    std::swap(connectionsCopy, internal_->connections);
   }
 
-  internal_->socket_v4.close();
-  while (!internal_->connections.empty()) {
-    auto it = internal_->connections.begin();
-    LOCAL_INFO("HttpServer[%d]::stop() - closing connection %d", fd, it->first);
-    internal_->closeConnection(lock, it->first, "HttpServer::stop()");
+  for (auto connection: connectionsCopy) {
+    int fd = connection->fd();
+    LOCAL_INFO("HttpServer[%d]::stop() - dropping connection %d", listenFd, fd);
+    connection->detachFromServer(true);
   }
+
   return Error::Ok;
 }
 
@@ -200,20 +206,24 @@ PollSet* HttpServer::getPollSet() const
 
 std::shared_ptr<HttpServerConnection> HttpServer::makeConnection(const std::shared_ptr<network::NetSocket>& socket)
 {
-  return std::make_shared<HttpServerConnection>(this, socket, internal_->pollSet);
+  return std::make_shared<HttpServerConnection>(internal_->lifetime, socket);
 }
-
 
 void HttpServer::acceptClient(const std::shared_ptr<Lifetime<HttpServer>>& lifetime, network::NetSocket* sock)
 {
+  if (!sock)
+    return;
+
   // This callback is called from PollSet thread.
-  std::unique_lock lock(*lifetime);
-  if (!lifetime->alive)
+  // Check if server instance is still alive and usable.
+  auto lock = lifetime->getLock();
+  if (!lifetime->valid(lock))
     return;
 
   if (!internal_)
     return;
-  if (!sock)
+
+  if (internal_->stoppingListeners)
     return;
 
   auto [clientSock, err] = sock->accept();
@@ -223,7 +233,6 @@ void HttpServer::acceptClient(const std::shared_ptr<Lifetime<HttpServer>>& lifet
     return;
   }
 
-  int fd = clientSock->fd();
   MINIROS_DEBUG("HttpServer::accept() - accepting new client fd=%d", clientSock->fd());
 
   clientSock->setNonBlock();
@@ -233,29 +242,9 @@ void HttpServer::acceptClient(const std::shared_ptr<Lifetime<HttpServer>>& lifet
 
   std::shared_ptr<HttpServerConnection> connection = makeConnection(clientSock);
   connection->setEndpointCollection(internal_->endpoints);
-
-  internal_->connections[fd] = connection;
-  auto internalCopy = internal_->lifetime;
-
-  internal_->pollSet->addSocket(fd, PollSet::EventIn | PollSet::EventUpdate,
-    [this, wconnection = std::weak_ptr(connection), fd, internalCopy](int flags)
-    {
-      // HttpServerConnection can probably be destroyed here.
-      std::unique_lock lock(*internalCopy);
-
-      auto connection = wconnection.lock();
-      if (!connection)
-        return 0;
-      int newFlags = connection->handleEvents(flags);
-      if (!internalCopy->alive) {
-        return 0;
-      }
-      /*
-      if (!newFlags) {
-        internal_->closeConnection(lock, fd, "EOF");
-      }*/
-      return newFlags;
-  }, internalCopy, THIS_LOCATION);
+  internal_->connections.insert(connection);
+  // Connection object will start receiving events from external thread.
+  connection->attachPollSet(internal_->pollSet);
 }
 
 Error HttpServer::registerEndpoint(std::unique_ptr<EndpointFilter>&& filter, const std::shared_ptr<EndpointHandler>& handler, const CallbackQueuePtr& cb)

--- a/src/http/http_server_connection.cpp
+++ b/src/http/http_server_connection.cpp
@@ -55,17 +55,14 @@ void HttpServerConnection::attachPollSet(PollSet* poll_set)
   assert(!poll_set_);
   assert(poll_set);
   poll_set_ = poll_set;
-  poll_set_->addSocket(socket_->fd(), PollSet::EventIn | PollSet::EventUpdate,
+  poll_set_->addSocket(socket_->fd(), PollSet::EventIn,
     [wconnection = weak_from_this()](int flags)
     {
       auto connection = wconnection.lock();
       if (!connection)
         return 0;
-      int newFlags = connection->handleEvents(flags);
-      if (!newFlags) {
-        //closeConnection(lock, fd, "EOF");
-      }
-      return newFlags;
+      connection->handleEvents(flags);
+      return 0;
   }, {}, THIS_LOCATION);
 }
 
@@ -346,7 +343,7 @@ void HttpServerConnection::handleWriteResponse(Lock& lock, int& evtFlags, bool f
   }
 }
 
-int HttpServerConnection::handleEvents(int evtFlags)
+void HttpServerConnection::handleEvents(int evtFlags)
 {
   Lock lock(guard_, THIS_LOCATION);
 
@@ -377,7 +374,8 @@ int HttpServerConnection::handleEvents(int evtFlags)
       PollSet::eventToString(evtFlags).c_str(),
       state_.toString());
   }
-  return eventsForState(state_);
+
+  poll_set_->setEvents(fd(), eventsForState(state_));
 }
 
 void HttpServerConnection::doWriteResponse(Lock& lock, const std::shared_ptr<HttpRequest>& req, Error error)

--- a/src/http/http_server_connection.cpp
+++ b/src/http/http_server_connection.cpp
@@ -14,6 +14,7 @@
 #include "internal/scoped_locks.h"
 #include "miniros/io/poll_set.h"
 #include "xmlrpcpp/XmlRpcException.h"
+#include "miniros/http/endpoint_collection.h"
 
 namespace miniros {
 namespace http {
@@ -33,6 +34,12 @@ HttpServerConnection::~HttpServerConnection()
   std::unique_lock<std::mutex> lock(guard_);
   LOCAL_DEBUG("~HttpServerConnection(%d)", debugFd_);
 }
+
+void HttpServerConnection::setEndpointCollection(const std::shared_ptr<internal::EndpointCollection>& endpoints)
+{
+  endpoints_ = endpoints;
+}
+
 
 const char* HttpServerConnection::State::toString() const
 {
@@ -172,7 +179,14 @@ bool HttpServerConnection::handleProcessRequest(Lock& lock)
   clientInfo.remoteAddress = socket_->peerAddress();
   LOCAL_DEBUG("Handling HTTP request to path=\"%s\"", endpoint.c_str());
 
-  auto [handler, cb] = server_->findEndpoint(http_frame_);
+  auto endpoints = endpoints_.lock();
+  if (!endpoints) {
+    LOCAL_ERROR("No handler for endpoint \"%s\"", endpoint.c_str());
+    doWriteResponse(lock, requestObject, Error::FileNotFound);
+    return true;
+  }
+
+  auto [handler, cb] = endpoints->findEndpoint(http_frame_);
 
   if (!handler) {
     LOCAL_ERROR("No handler for endpoint \"%s\"", endpoint.c_str());

--- a/src/http/http_server_connection.cpp
+++ b/src/http/http_server_connection.cpp
@@ -7,20 +7,24 @@
 // ROS log will write to the channel "miniros.http[.server]"
 #define MINIROS_PACKAGE_NAME "http"
 
+#include "internal/scoped_locks.h"
+#include "io/io.h"
+#include "miniros/callback_queue.h"
 #include "miniros/console.h"
+#include "miniros/http/endpoint_collection.h"
 #include "miniros/http/http_server.h"
 #include "miniros/http/http_server_connection.h"
-#include "miniros/callback_queue.h"
-#include "internal/scoped_locks.h"
+
+#include "internal/lifetime.h"
 #include "miniros/io/poll_set.h"
 #include "xmlrpcpp/XmlRpcException.h"
-#include "miniros/http/endpoint_collection.h"
 
 namespace miniros {
 namespace http {
 
-HttpServerConnection::HttpServerConnection(HttpServer* server, std::shared_ptr<network::NetSocket> socket, PollSet* poll_set)
-  :server_(server), socket_(socket), poll_set_(poll_set)
+HttpServerConnection::HttpServerConnection(const std::shared_ptr<Lifetime<HttpServer>>& server_lifetime,
+  std::shared_ptr<network::NetSocket> socket)
+  :server_lifetime_(server_lifetime), socket_(socket)
 {
   http_frame_.finishRequest();
   assert(socket);
@@ -33,6 +37,12 @@ HttpServerConnection::~HttpServerConnection()
 {
   std::unique_lock<std::mutex> lock(guard_);
   LOCAL_DEBUG("~HttpServerConnection(%d)", debugFd_);
+
+  if (poll_set_) {
+    if (socket_) {
+      poll_set_->delSocket(socket_->fd());
+    }
+  }
 }
 
 void HttpServerConnection::setEndpointCollection(const std::shared_ptr<internal::EndpointCollection>& endpoints)
@@ -40,6 +50,24 @@ void HttpServerConnection::setEndpointCollection(const std::shared_ptr<internal:
   endpoints_ = endpoints;
 }
 
+void HttpServerConnection::attachPollSet(PollSet* poll_set)
+{
+  assert(!poll_set_);
+  assert(poll_set);
+  poll_set_ = poll_set;
+  poll_set_->addSocket(socket_->fd(), PollSet::EventIn | PollSet::EventUpdate,
+    [wconnection = weak_from_this()](int flags)
+    {
+      auto connection = wconnection.lock();
+      if (!connection)
+        return 0;
+      int newFlags = connection->handleEvents(flags);
+      if (!newFlags) {
+        //closeConnection(lock, fd, "EOF");
+      }
+      return newFlags;
+  }, {}, THIS_LOCATION);
+}
 
 const char* HttpServerConnection::State::toString() const
 {
@@ -89,6 +117,22 @@ Error HttpServerConnection::doReadRequest(Lock& lock)
   LOCAL_DEBUG("HttpServerConnection(peer=%s fd=%d)::readRequest read %d/%d bytes.", peer.c_str(), fd, http_frame_.bodyLength(), http_frame_.contentLength());
   updateState(lock, state_ = State::ProcessRequest);
   return Error::Ok;
+}
+
+int HttpServerConnection::fd() const
+{
+  return socket_ ? socket_->fd() : MINIROS_INVALID_SOCKET;
+}
+
+bool HttpServerConnection::isDetachedFromParent() const
+{
+  if (!server_lifetime_)
+    return true;
+
+  auto lock = server_lifetime_->getLock();
+  if (!server_lifetime_->valid(lock))
+    return true;
+  return false;
 }
 
 class HttpServerCallback : public CallbackInterface {
@@ -167,8 +211,7 @@ bool HttpServerConnection::handleProcessRequest(Lock& lock)
 
   std::string endpoint{http_frame_.getPath()};
 
-  // Execute request:
-  if (!server_) {
+  if (isDetachedFromParent()) {
     LOCAL_ERROR("HttpServerConnection::handleEvents connection fd=%d detached from server", socket_->fd());
     prepareFaultResponse(Error::InternalError, *requestObject);
     return false;
@@ -222,7 +265,6 @@ void HttpServerConnection::handleDisconnect(Lock& lock)
   updateState(lock, State::Disconnected);
 }
 
-
 void HttpServerConnection::handleReadRequest(Lock& lock, int& evtFlags, bool fallThrough)
 {
   if (!fallThrough && evtFlags & PollSet::EventError) {
@@ -250,7 +292,6 @@ void HttpServerConnection::handleReadRequest(Lock& lock, int& evtFlags, bool fal
   }
 }
 
-
 void HttpServerConnection::handleWriteResponse(Lock& lock, int& evtFlags, bool fallThrough)
 {
   if (!fallThrough && evtFlags & PollSet::EventError) {
@@ -269,7 +310,6 @@ void HttpServerConnection::handleWriteResponse(Lock& lock, int& evtFlags, bool f
       r = socket_->write2(
         response_header_buffer_.c_str(), response_header_buffer_.size(),
         responseBody.c_str(), responseBodySize, data_sent_);
-
     } else {
       const char* data = response_header_buffer_.c_str() + data_sent_;
       size_t toSend = response_header_buffer_.size() - data_sent_;
@@ -311,6 +351,9 @@ int HttpServerConnection::handleEvents(int evtFlags)
   Lock lock(guard_, THIS_LOCATION);
 
   const int startEvt = evtFlags;
+
+  // TODO: Disable it once most transport bugs are resolved.
+  LOCAL_DEBUG("HttpServerConnection[%d]::handleEvents(%s) in state %s", debugFd_, PollSet::eventToString(startEvt).c_str(), state_.toString());
 
   // Set to true if we transition multiple FSM states.
   bool stateFallback = false;
@@ -366,7 +409,7 @@ int HttpServerConnection::eventsForState(State state) const
   }
 }
 
-void HttpServerConnection::close()
+void HttpServerConnection::closeSocket()
 {
   socket_->close();
   socket_.reset();
@@ -379,10 +422,14 @@ void HttpServerConnection::resetResponse()
   data_sent_ = 0;
 }
 
-void HttpServerConnection::detach()
+void HttpServerConnection::detachFromServer(bool close)
 {
+  server_lifetime_ = {};
+
   Lock lock(guard_, THIS_LOCATION);
-  server_ = nullptr;
+  if (close) {
+    // TODO: ???
+  }
 }
 
 void HttpServerConnection::onAsyncRequestComplete(std::shared_ptr<HttpRequest> request, Error err)

--- a/src/internal/watchdog.cpp
+++ b/src/internal/watchdog.cpp
@@ -103,7 +103,7 @@ void Watchdog::threadFunc()
         }
         else
         {
-          MINIROS_DEBUG_NAMED("watchdog", "Watchdog timeout expired, raised signal %d", signal_);
+          MINIROS_ERROR_NAMED("watchdog", "Watchdog timeout expired, raised signal %d", signal_);
         }
 #else
         MINIROS_WARN_NAMED("watchdog", "Watchdog timeout expired, but signal raising is not supported on Windows");

--- a/src/internal/xml_tools.cpp
+++ b/src/internal/xml_tools.cpp
@@ -10,6 +10,7 @@
 #include "miniros/xmlrpcpp/XmlRpcValue.h"
 
 #include "miniros/console.h"
+#include "rosconsole/local_log.h"
 
 namespace miniros {
 namespace xml {
@@ -495,26 +496,23 @@ bool XmlCodec::validateXmlrpcResponse(const std::string& method, const Value &re
 {
   if (response.getType() != Value::TypeArray)
   {
-    MINIROS_DEBUG("XML-RPC call [%s] didn't return an array",
-        method.c_str());
+    //LOCAL_DEBUG("XML-RPC call [%s] didn't return an array", method.c_str());
     return false;
   }
   if (response.size() != 2 && response.size() != 3)
   {
-    MINIROS_DEBUG("XML-RPC call [%s] didn't return a 2 or 3-element array",
-        method.c_str());
+    //LOCAL_DEBUG("XML-RPC call [%s] didn't return a 2 or 3-element array", method.c_str());
     return false;
   }
   if (response[0].getType() != Value::TypeInt)
   {
-    MINIROS_DEBUG("XML-RPC call [%s] didn't return a int as the 1st element",
-        method.c_str());
+    //LOCAL_DEBUG("XML-RPC call [%s] didn't return an int as the 1st element", method.c_str());
     return false;
   }
   int status_code = response[0];
   if (response[1].getType() != Value::TypeString)
   {
-    MINIROS_DEBUG("XML-RPC call [%s] didn't return a string as the 2nd element", method.c_str());
+    //LOCAL_DEBUG("XML-RPC call [%s] didn't return a string as the 2nd element", method.c_str());
     return false;
   }
   std::string status_string = response[1];

--- a/src/io/poll_set.cpp
+++ b/src/io/poll_set.cpp
@@ -592,6 +592,9 @@ std::string PollSet::eventToString(int event)
 #ifdef POLLRDHUP
   EVT_FLAG(POLLRDHUP, "Rdh");
 #endif
+
+  // Custom timer event flag.
+  EVT_FLAG(EventTimer, 'T');
   if (event != 0) {
     result += "_";
     result += std::to_string(event);

--- a/src/io/poll_set.cpp
+++ b/src/io/poll_set.cpp
@@ -384,8 +384,6 @@ void PollSet::signal()
   }
 }
 
-#define VERY_DETAILED_LOG
-
 void PollSet::update(int poll_timeout)
 {
   MINIROS_PROFILE_SCOPE2("PollSet", "update");

--- a/src/io/poll_set.cpp
+++ b/src/io/poll_set.cpp
@@ -186,7 +186,11 @@ bool PollSet::addSocket(int fd, int events, const SocketUpdateFunc& update_func,
 
     internal_->sockets_changed_ = true;
   }
-  LOCAL_DEBUG("PollSet::addSocket(%d) evt=%s", fd, eventToString(events).c_str());
+  if (info.updateEvents_) {
+    LOCAL_DEBUG("PollSet::addSocket(%d) evt=%s with dynamic adjust", fd, eventToString(events).c_str());
+  } else {
+    LOCAL_DEBUG("PollSet::addSocket(%d) evt=%s", fd, eventToString(events).c_str());
+  }
 
   signal();
 
@@ -254,11 +258,19 @@ bool PollSet::addEvents(int sock, int events)
   // Adding back to watcher if we added new events.
   if (oldEvents == 0) {
     if (!add_socket_to_watcher(internal_->epfd_, sock, it->second.events_)) {
-      LOCAL_ERROR("PollSet::addEvents(%d) - failed to add FD to watcher: %s", sock, strerror(errno));
+      LOCAL_ERROR("PollSet::addEvents(%d, %s) - failed to add FD to watcher: %s", sock,
+        eventToString(events).c_str(), strerror(errno));
+    } else {
+      LOCAL_INFO("PollSet::addEvents(%d, %s) - set events", sock,
+        eventToString(events).c_str());
     }
   } else {
     if (!set_events_on_socket(internal_->epfd_, sock, it->second.events_)) {
-      LOCAL_ERROR("PollSet::addEvents(%d) - failed update events in watcher: %s", sock, strerror(errno));
+      LOCAL_ERROR("PollSet::addEvents(%d, %s) - failed update events in watcher: %s", sock,
+        eventToString(events).c_str(), strerror(errno));
+    } else {
+      LOCAL_INFO("PollSet::addEvents(%d, %s) - added events", sock,
+        eventToString(events).c_str());
     }
   }
 
@@ -309,7 +321,7 @@ bool PollSet::setEvents(int sock, int events)
 
   if (it == internal_->socket_info_.end())
   {
-    LOCAL_WARN("PollSet: Tried to set events [%d] to fd [%d] which does not exist in this pollset", events, sock);
+    LOCAL_ERROR("PollSet::setEvents(%d, %s) - fd is not registered", sock, eventToString(events).c_str());
     return false;
   }
 
@@ -320,22 +332,22 @@ bool PollSet::setEvents(int sock, int events)
   it->second.events_ = events;
   if (oldEvents == 0) {
     if (!add_socket_to_watcher(internal_->epfd_, sock, it->second.events_)) {
-      LOCAL_ERROR("PollSet::setEvents(%d, %d) failed to add socket to watcher: %s", sock, events, strerror(errno));
+      LOCAL_ERROR("PollSet::setEvents(%d, %s) failed to add socket to watcher: %s", sock, eventToString(events).c_str(), strerror(errno));
       return false;
     }
-    LOCAL_DEBUG("PollSet::setEvents(%d, %d) added socket to watcher", sock, events);
+    LOCAL_DEBUG("PollSet::setEvents(%d, %s) added socket to watcher", sock, eventToString(events).c_str());
   } else if (it->second.events_ == 0) {
     if (!del_socket_from_watcher(internal_->epfd_, sock)) {
-      LOCAL_WARN("PollSet::setEvents(%d, %d) failed to delete socket from watcher: %s", sock, events, strerror(errno));
+      LOCAL_WARN("PollSet::setEvents(%d, %s) failed to delete socket from watcher: %s", sock, eventToString(events).c_str(), strerror(errno));
       return false;
     }
-    LOCAL_DEBUG("PollSet::setEvents(%d, %d) deleted socket from watcher", sock, events);
+    LOCAL_DEBUG("PollSet::setEvents(%d, %s) deleted socket from watcher", sock, eventToString(events).c_str());
   } else {
     if (!set_events_on_socket(internal_->epfd_, sock, it->second.events_)) {
-      LOCAL_WARN("PollSet::setEvents(%d, %d) failed deleted socket from watcher: %s", sock, events, strerror(errno));
+      LOCAL_WARN("PollSet::setEvents(%d, %s) failed deleted socket from watcher: %s", sock, eventToString(events).c_str(), strerror(errno));
       return false;
     }
-    LOCAL_DEBUG("PollSet::setEvents(%d, %d) updated events", sock, events);
+    LOCAL_DEBUG("PollSet::setEvents(%d, %s) updated events", sock, eventToString(events).c_str());
   }
   internal_->sockets_changed_ = true;
   signal();
@@ -372,6 +384,7 @@ void PollSet::signal()
   }
 }
 
+#define VERY_DETAILED_LOG
 
 void PollSet::update(int poll_timeout)
 {
@@ -483,15 +496,13 @@ void PollSet::update(int poll_timeout)
           if (!del_socket_from_watcher(internal_->epfd_, fd)) {
             LOCAL_WARN("PollSet fd=%d failed to remove from watcher", fd);
           }
-          it->second.events_ = ret;
         } else {
-          if (set_events_on_socket(internal_->epfd_, fd, ret)) {
-            it->second.events_ = ret;
-          } else {
+          if (!set_events_on_socket(internal_->epfd_, fd, ret)) {
             LOCAL_ERROR("PollSet fd=%d failed to set events %d on socket: %s", fd, it->second.events_, strerror(errno));
           }
         }
-        LOCAL_DEBUG("PollSet fd=%d adjust events from %s to %s", fd, eventToString(info.events_).c_str(), eventToString(ret).c_str());
+        LOCAL_DEBUG("PollSet fd=%d adjust events by callback from %s to %s", fd, eventToString(info.events_).c_str(), eventToString(ret).c_str());
+        it->second.events_ = ret;
       }
     }
   } // for socket event
@@ -576,6 +587,9 @@ int PollSet::onLocalPipeEvents(int events)
 
 std::string PollSet::eventToString(int event)
 {
+  if (event == 0) {
+    return "nil";
+  }
   std::string result;
 #define EVT_FLAG(flag, ch) if (event & flag) { result += ch; event &= ~flag; }
   EVT_FLAG(POLLIN, 'I');

--- a/src/io/poll_set.cpp
+++ b/src/io/poll_set.cpp
@@ -48,6 +48,7 @@
 
 #include "miniros/rosconsole/local_log.h"
 
+#include <condition_variable>
 
 namespace miniros
 {
@@ -128,8 +129,24 @@ PollSet::PollSet()
 
 PollSet::~PollSet()
 {
+  if (internal_->signal_pipe_[0] != MINIROS_INVALID_SOCKET) {
+    delSocket(internal_->signal_pipe_[0]);
+  }
+
   close_signal_pair(internal_->signal_pipe_);
   close_socket_watcher(internal_->epfd_);
+
+  if (!internal_->socket_info_.empty()) {
+    LOCAL_ERROR("PollSet::~PollSet() discovered %zu dangling sockets", internal_->socket_info_.size());
+
+    for (const auto& [fd, info]: internal_->socket_info_) {
+      if (info.loc_.valid()) {
+        LOCAL_ERROR("\tfd=%d: %s", fd, info.loc_.str().c_str());
+      } else {
+        LOCAL_ERROR("\tfd=%d: unknown code location", fd);
+      }
+    }
+  }
   internal_.reset();
 }
 
@@ -178,7 +195,7 @@ bool PollSet::addSocket(int fd, int events, const SocketUpdateFunc& update_func,
 
 bool PollSet::delSocket(int fd)
 {
-  if(fd < 0)
+  if (fd < 0)
   {
     return false;
   }
@@ -458,6 +475,7 @@ void PollSet::update(int poll_timeout)
       delSocket(fd);
     }
     else if (info.updateEvents_ && ret != info.events_) {
+      // TODO: Reimplement it through setEvents(fd, ret);
       std::scoped_lock<std::mutex> lock(internal_->socket_info_mutex_);
       auto it = internal_->socket_info_.find(fd);
       if (it != internal_->socket_info_.end() && it->second.events_ != ret) {

--- a/src/network/net_address.cpp
+++ b/src/network/net_address.cpp
@@ -261,7 +261,6 @@ Error addressFromString(NetAddress::Type type, const std::string& address, int p
     }
   }
 
-  // Free the addrinfo structure
   freeaddrinfo(res);
   return assigned ? Error::Ok : Error::InvalidValue;
 }

--- a/src/network/net_address.cpp
+++ b/src/network/net_address.cpp
@@ -479,10 +479,35 @@ int NetAddress::port() const
   return 0;
 }
 
-
 std::string NetAddress::str() const
 {
   std::stringstream ss;
+  ss << address;
+  int p = port();
+  if (p) {
+    ss << ":" << p;
+  }
+  return ss.str();
+}
+
+std::string NetAddress::lstr() const
+{
+  std::stringstream ss;
+  switch (type_) {
+    case Type::AddressIPv4:
+      ss << "ip4:";
+      break;
+    case Type::AddressIPv6:
+      ss << "ip6:";
+      break;
+    case Type::AddressUnspecified:
+      ss << "un:";
+      break;
+    case Type::AddressInvalid:
+      ss << "invalid:";
+    default:
+      break;
+  }
   ss << address;
   int p = port();
   if (p) {

--- a/src/network/net_address.cpp
+++ b/src/network/net_address.cpp
@@ -10,6 +10,7 @@
 
 #include "miniros/network/net_address.h"
 #include "miniros/network/url.h"
+#include "rosconsole/local_log.h"
 
 namespace miniros {
 namespace network {
@@ -24,6 +25,7 @@ NetAddress::NetAddress(NetAddress&& other) noexcept
   std::swap(rawAddress_, other.rawAddress_);
   std::swap(rawAddressSize_, other.rawAddressSize_);
   std::swap(address, other.address);
+  std::swap(unspecified, other.unspecified);
 
   type_ = other.type_;
 }
@@ -42,15 +44,11 @@ size_t getAddressSize(const NetAddress::Type type)
 
 NetAddress::NetAddress(const NetAddress& other)
 {
-  if (other.rawAddress_ && (other.type_ == Type::AddressIPv4 || other.type_ == Type::AddressIPv6)) {
-    size_t size = getAddressSize(other.type_);
-    sockaddr_in* addr = static_cast<sockaddr_in*>(malloc(size));
-    rawAddress_ = addr;
-    memcpy(rawAddress_, other.rawAddress_, getAddressSize(other.type_));
-    type_ = other.type_;
-  } else {
-    type_ = Type::AddressInvalid;
+  if (other.rawAddress_ && other.rawAddressSize_ > 0) {
+    rawAddress_ = malloc(other.rawAddressSize_);
+    memcpy(rawAddress_, other.rawAddress_, other.rawAddressSize_);
   }
+  type_ = other.type_;
   address = other.address;
   unspecified = other.unspecified;
   rawAddressSize_ = other.rawAddressSize_;
@@ -65,16 +63,14 @@ NetAddress& NetAddress::operator=(const NetAddress& other)
 {
   if (this == &other)
     return *this;
+
   reset();
 
-  if (other.rawAddress_ && (other.type_ == Type::AddressIPv4 || other.type_ == Type::AddressIPv6)) {
-    sockaddr_in* addr = static_cast<sockaddr_in*>(malloc(sizeof(sockaddr_in)));
-    rawAddress_ = addr;
-    memcpy(rawAddress_, other.rawAddress_, getAddressSize(other.type_));
-    type_ = other.type_;
-  } else {
-    type_ = Type::AddressInvalid;
+  if (other.rawAddress_ && other.rawAddressSize_ > 0) {
+    rawAddress_ = malloc(other.rawAddressSize_);
+    memcpy(rawAddress_, other.rawAddress_, other.rawAddressSize_);
   }
+  type_ = other.type_;
   address = other.address;
   unspecified = other.unspecified;
   rawAddressSize_ = other.rawAddressSize_;
@@ -101,9 +97,12 @@ bool NetAddress::isUnspecified() const
   return unspecified;
 }
 
-NetAddress NetAddress::fromString(Type type, const std::string& address, int port)
+Error addressFromString(NetAddress::Type type, const std::string& address, int port, NetAddress& result)
 {
-  NetAddress result;
+  // Port 0 is specifically allowed.
+  if (address.empty() || port < 0 || port > 65535) {
+    return Error::InvalidValue;
+  }
 
   // First, try to parse as IP address directly
   if (type == NetAddress::AddressIPv4) {
@@ -113,8 +112,9 @@ NetAddress NetAddress::fromString(Type type, const std::string& address, int por
       addr.sin_port = htons(port);
       result.assignRawAddress(type, &addr, sizeof(addr));
       result.address = address;
-      return result;
+      return Error::Ok;
     }
+    // Fallback to DNS resolver.
   } else if (type == NetAddress::AddressIPv6) {
     sockaddr_in6 addr{};
     addr.sin6_family = AF_INET6;
@@ -122,35 +122,37 @@ NetAddress NetAddress::fromString(Type type, const std::string& address, int por
     if (inet_pton(AF_INET6, address.c_str(), &addr.sin6_addr) == 1) {
       result.assignRawAddress(type, &addr, sizeof(addr));
       result.address = address;
-      return result;
+      return Error::Ok;
     }
+    // Fallback to DNS resolver.
   } else if (type == NetAddress::AddressUnspecified) {
     // Try IPv6 first, then IPv4
     sockaddr_in6 addr6{};
     addr6.sin6_family = AF_INET6;
     addr6.sin6_port = htons(port);
     if (inet_pton(AF_INET6, address.c_str(), &addr6.sin6_addr) == 1) {
-      result.assignRawAddress(AddressIPv6, &addr6, sizeof(addr6));
+      result.assignRawAddress(NetAddress::AddressIPv6, &addr6, sizeof(addr6));
       result.address = address;
-      return result;
+      return Error::Ok;
     }
     sockaddr_in addr4{};
     addr4.sin_family = AF_INET;
     if (inet_pton(AF_INET, address.c_str(), &addr4.sin_addr) == 1) {
       addr4.sin_port = htons(port);
-      result.assignRawAddress(AddressIPv4, &addr4, sizeof(addr4));
+      result.assignRawAddress(NetAddress::AddressIPv4, &addr4, sizeof(addr4));
       result.address = address;
-      return result;
+      return Error::Ok;
     }
+    // Fallback to DNS resolver.
   } else {
     // Invalid type
-    return result;
+    return Error::InvalidValue;
   }
 
   // If IP parsing failed, try DNS resolution
   struct addrinfo hints{};
   struct addrinfo* res = nullptr;
-  
+
   // Set up hints based on type preference
   if (type == NetAddress::AddressIPv4) {
     hints.ai_family = AF_INET;
@@ -163,40 +165,74 @@ NetAddress NetAddress::fromString(Type type, const std::string& address, int por
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_flags = AI_ADDRCONFIG;
 
-  // Convert port to string for getaddrinfo
   std::string portStr = std::to_string(port);
-  
+
   int err = getaddrinfo(address.c_str(), portStr.c_str(), &hints, &res);
   if (err != 0) {
-    // DNS resolution failed
-    return result;
+    // Errors and descriptions are taken from `man getaddrinfo`.
+    switch (err) {
+#if defined(EAI_SYSTEM)
+      case EAI_SYSTEM: {
+        const char* sysError = strerror(errno);
+        LOCAL_DEBUG("addressFromString(%s) - failed: %s", address.c_str(), sysError);
+        return Error::SystemError;
+      }
+#endif
+      case EAI_MEMORY:
+        return Error::OutOfMemory;
+#if defined(EAI_ADDRFAMILY)
+      case EAI_ADDRFAMILY:
+#endif
+      case EAI_BADFLAGS:
+      case EAI_FAMILY:
+      case EAI_SERVICE:
+      case EAI_SOCKTYPE:
+        // Invalid call parameters or unsupported combination.
+      case EAI_NONAME:
+        // Invalid host name (or unknown host/service).
+        return Error::InvalidValue;
+      case EAI_AGAIN:
+#ifndef WIN32
+      // This constant is defined as an alias on Win32 and will not compile.
+      case EAI_NODATA:
+#endif
+      case EAI_FAIL:
+        // Name can be valid but is not resolvable right now.
+        return Error::AddressIsUnknown;
+      default:
+        break;
+    }
+    return Error::SystemError;
   }
 
   // Try to find a matching address
   // For AddressUnspecified, prefer IPv6 first, then IPv4
+  bool assigned = false;
   if (type == NetAddress::AddressUnspecified) {
     // First pass: look for IPv6 addresses
     for (struct addrinfo* rp = res; rp != nullptr; rp = rp->ai_next) {
       if (rp->ai_family == AF_INET6) {
         const sockaddr_in6* addr6 = reinterpret_cast<const sockaddr_in6*>(rp->ai_addr);
-        result.assignRawAddress(AddressIPv6, rp->ai_addr, rp->ai_addrlen);
+        result.assignRawAddress(NetAddress::AddressIPv6, rp->ai_addr, rp->ai_addrlen);
         char ipBuffer[INET6_ADDRSTRLEN];
         if (inet_ntop(AF_INET6, &addr6->sin6_addr, ipBuffer, sizeof(ipBuffer))) {
           result.address = ipBuffer;
         }
+        assigned = true;
         freeaddrinfo(res);
-        return result;
+        return Error::Ok;
       }
     }
     // Second pass: look for IPv4 addresses if no IPv6 found
     for (struct addrinfo* rp = res; rp != nullptr; rp = rp->ai_next) {
       if (rp->ai_family == AF_INET) {
         const sockaddr_in* addr4 = reinterpret_cast<const sockaddr_in*>(rp->ai_addr);
-        result.assignRawAddress(AddressIPv4, rp->ai_addr, rp->ai_addrlen);
+        result.assignRawAddress(NetAddress::AddressIPv4, rp->ai_addr, rp->ai_addrlen);
         char ipBuffer[INET_ADDRSTRLEN];
         if (inet_ntop(AF_INET, &addr4->sin_addr, ipBuffer, sizeof(ipBuffer))) {
           result.address = ipBuffer;
         }
+        assigned = true;
         break;
       }
     }
@@ -205,19 +241,21 @@ NetAddress NetAddress::fromString(Type type, const std::string& address, int por
     for (struct addrinfo* rp = res; rp != nullptr; rp = rp->ai_next) {
       if (rp->ai_family == AF_INET && type == NetAddress::AddressIPv4) {
         const sockaddr_in* addr4 = reinterpret_cast<const sockaddr_in*>(rp->ai_addr);
-        result.assignRawAddress(AddressIPv4, rp->ai_addr, rp->ai_addrlen);
+        result.assignRawAddress(NetAddress::AddressIPv4, rp->ai_addr, rp->ai_addrlen);
         char ipBuffer[INET_ADDRSTRLEN];
         if (inet_ntop(AF_INET, &addr4->sin_addr, ipBuffer, sizeof(ipBuffer))) {
           result.address = ipBuffer;
         }
+        assigned = true;
         break;
       } else if (rp->ai_family == AF_INET6 && type == NetAddress::AddressIPv6) {
         const sockaddr_in6* addr6 = reinterpret_cast<const sockaddr_in6*>(rp->ai_addr);
-        result.assignRawAddress(AddressIPv6, rp->ai_addr, rp->ai_addrlen);
+        result.assignRawAddress(NetAddress::AddressIPv6, rp->ai_addr, rp->ai_addrlen);
         char ipBuffer[INET6_ADDRSTRLEN];
         if (inet_ntop(AF_INET6, &addr6->sin6_addr, ipBuffer, sizeof(ipBuffer))) {
           result.address = ipBuffer;
         }
+        assigned = true;
         break;
       }
     }
@@ -225,6 +263,14 @@ NetAddress NetAddress::fromString(Type type, const std::string& address, int por
 
   // Free the addrinfo structure
   freeaddrinfo(res);
+  return assigned ? Error::Ok : Error::InvalidValue;
+}
+
+
+NetAddress NetAddress::fromString(Type type, const std::string& address, int port)
+{
+  NetAddress result;
+  Error err = addressFromString(type, address, port, result);
   return result;
 }
 

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -27,13 +27,10 @@ struct NetSocket::Internal {
   /// Do we own the FD and close it on exit.
   bool own = false;
 
-  /// Socket is listening for connections.
-  bool listening = false;
-
   /// Checked if socket is in non-blocking mode.
   bool nonblock = false;
 
-  bool connecting = true;
+  State state = State::Invalid;
 
   /// Address of connected endpoint.
   NetAddress peer_address;
@@ -45,8 +42,7 @@ struct NetSocket::Internal {
       close_socket(fd);
     }
     own = false;
-    listening = false;
-    connecting = false;
+    state = State::Invalid;
     fd = MINIROS_INVALID_SOCKET;
     peer_address.reset();
   }
@@ -57,12 +53,13 @@ NetSocket::NetSocket()
   internal_.reset(new Internal());
 }
 
-NetSocket::NetSocket(int fd, Type type, bool own)
+NetSocket::NetSocket(int fd, Type type, bool own, State state)
 {
   internal_.reset(new Internal());
   internal_->fd = fd;
   internal_->own = own;
   internal_->type = type;
+  internal_->state = state;
   if (fd) {
     MINIROS_DEBUG_NAMED("socket", "NetSocket(%d)", fd);
   }
@@ -75,6 +72,7 @@ NetSocket::~NetSocket()
 
 void NetSocket::close()
 {
+  disconnect();
   internal_->close();
 }
 
@@ -83,7 +81,7 @@ Error NetSocket::listen(int maxQueuedClients)
   if (!valid())
     return Error::InvalidValue;
   if (::listen(internal_->fd, maxQueuedClients) == 0) {
-    internal_->listening = true;
+    internal_->state = State::Listening;
     return Error::Ok;
   }
 
@@ -179,10 +177,28 @@ int NetSocket::fd() const
   return internal_ ? internal_->fd : MINIROS_INVALID_SOCKET;
 }
 
-Error NetSocket::tcpListen(int port, NetAddress::Type type, int maxQueuedClients)
+Error NetSocket::tcpSocket(NetAddress::Type type)
 {
-  if (valid())
-    close();
+  Type sockType = Type::Invalid;
+  if (type == NetAddress::AddressIPv4)
+    sockType = Type::TCP;
+  else if (type == NetAddress::AddressIPv6)
+    sockType = Type::TCPv6;
+
+  // Socket is already created. Try to reuse it.
+  if (valid()) {
+    // Same type - directly reuse it.
+    if (sockType == internal_->type) {
+      if (internal_->state != State::Initial) {
+        disconnect();
+        return Error::Ok;
+      }
+    } else {
+      // Different type. It must be closed.
+      close();
+    }
+  }
+
   int addrType = 0;
   if (type == NetAddress::AddressIPv6)
     addrType = AF_INET6;
@@ -199,24 +215,32 @@ Error NetSocket::tcpListen(int port, NetAddress::Type type, int maxQueuedClients
   }
   internal_->fd = fd;
   internal_->own = true;
-
-  if (type == NetAddress::AddressIPv4)
-    internal_->type = Type::TCP;
-  else if (type == NetAddress::AddressIPv6)
-    internal_->type = Type::TCPv6;
+  internal_->type = sockType;
+  internal_->state = State::Initial;
 
   if (Error err = setReuseAddr(); !err) {
     close();
     return err;
   }
+  return Error::Ok;
+}
 
-  if (Error err = bind(port); !err) {
-    MINIROS_ERROR_NAMED("socket", "NetSocket[%d]::tcpListen() - error binding to port %d: %s", fd, port, err.toString());
+Error NetSocket::tcpListen(int port, NetAddress::Type type, int maxQueuedClients)
+{
+  if (Error err = tcpSocket(type); !err) {
+    MINIROS_ERROR_NAMED("socket", "NetSocket[%d]::tcpListen() - error creating TCP socket: %s", internal_->fd, err.toString());
     close();
     return err;
   }
+
+  if (Error err = bind(port); !err) {
+    MINIROS_ERROR_NAMED("socket", "NetSocket[%d]::tcpListen() - error binding to port %d: %s", internal_->fd, port, err.toString());
+    close();
+    return err;
+  }
+
   if (Error err = listen(maxQueuedClients); !err) {
-    MINIROS_ERROR_NAMED("socket", "NetSocket[%d]::tcpListen() - error while entering listening mode: %s", fd, err.toString());
+    MINIROS_ERROR_NAMED("socket", "NetSocket[%d]::tcpListen() - error while entering listening mode: %s", internal_->fd, err.toString());
     close();
     return err;
   }
@@ -225,38 +249,15 @@ Error NetSocket::tcpListen(int port, NetAddress::Type type, int maxQueuedClients
 
 Error NetSocket::tcpConnect(const NetAddress& address, bool nonblock)
 {
-  if (valid()) {
-    close();
-  }
-
   if (!address.valid()) {
     return Error::InvalidAddress;
   }
 
-  // Determine address family based on address type
-  int domain = 0;
-  Type socketType = Type::Invalid;
-  if (address.type() == NetAddress::AddressIPv6) {
-    domain = AF_INET6;
-    socketType = Type::TCPv6;
-  } else if (address.type() == NetAddress::AddressIPv4) {
-    domain = AF_INET;
-    socketType = Type::TCP;
-  } else {
-    return Error::InvalidValue;
+  if (Error err = tcpSocket(address.type()); !err) {
+    MINIROS_ERROR_NAMED("socket", "NetSocket[%d]::tcpListen() - error creating TCP socket: %s", internal_->fd, err.toString());
+    close();
+    return err;
   }
-
-  // Create TCP socket
-  int fd = socket(domain, SOCK_STREAM, IPPROTO_TCP);
-  if (fd < 0) {
-    const char* err = last_socket_error_string();
-    MINIROS_ERROR_NAMED("socket", "NetSocket::tcpConnect(%s) Error while trying to create TCP socket: %s", address.str().c_str(), err);
-    return Error::SystemError;
-  }
-
-  internal_->fd = fd;
-  internal_->type = socketType;
-  internal_->own = true;
 
   // Connect to peer address
   const sockaddr* rawAddr = static_cast<const sockaddr*>(address.rawAddress());
@@ -272,7 +273,7 @@ Error NetSocket::tcpConnect(const NetAddress& address, bool nonblock)
     if (err == EINPROGRESS && internal_->nonblock) {
       // This is expected error and connection attempt will be retried later.
       // This socket should be added to PollSet to get notification when connection is ready.
-      internal_->connecting = true;
+      internal_->state = State::Connecting;
       return Error::WouldBlock;
     }
     // Close socket on error
@@ -358,7 +359,7 @@ std::pair<std::shared_ptr<NetSocket>, Error> NetSocket::accept()
     return {{}, Error::SystemError};
   }
 
-  std::shared_ptr<NetSocket> sock(new NetSocket(fd, internal_->type, true));
+  std::shared_ptr<NetSocket> sock(new NetSocket(fd, internal_->type, true, State::Connected));
   NetAddress address;
   fillAddress(&addr, address);
   sock->internal_->peer_address = address;
@@ -747,7 +748,7 @@ Error NetSocket::checkConnected()
     return Error::InternalError;
   }
 
-  if (!internal_->connecting)
+  if (internal_->state != State::Connecting)
     return Error::Ok;
 
   int err = 0;
@@ -755,7 +756,7 @@ Error NetSocket::checkConnected()
   if (getsockopt(internal_->fd, SOL_SOCKET, SO_ERROR, (char*)&err, &error_code_len) == 0) {
     if (err == 0) {
       // Connection successful
-      internal_->connecting = false;
+      internal_->state = State::Connected;
       return Error::Ok;
     }
 
@@ -781,8 +782,30 @@ Error NetSocket::checkConnected()
 bool NetSocket::isConnecting() const
 {
   if (internal_)
-    return internal_->connecting;
+    return internal_->state == State::Connecting;
   return false;
+}
+
+bool NetSocket::isConnected() const
+{
+  if (internal_)
+    return internal_->state == State::Connected;
+  return false;
+}
+
+void NetSocket::disconnect()
+{
+  if (!internal_)
+    return;
+  if (internal_->state == State::Connecting || internal_->state == State::Connected || internal_->state == State::Unknown) {
+#ifdef WIN32
+    int flags = SD_BOTH;
+#else
+    int flags = SHUT_RDWR;
+#endif
+    shutdown(internal_->fd, flags);
+    internal_->state = State::Initial;
+  }
 }
 
 }

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -38,6 +38,7 @@ struct NetSocket::Internal {
   /// Close socket and reset all data.
   void close()
   {
+    LOCAL_DEBUG("Socket[%d]::close()", fd);
     if (own && fd != MINIROS_INVALID_SOCKET) {
       close_socket(fd);
     }
@@ -193,6 +194,8 @@ Error NetSocket::tcpSocket(NetAddress::Type type)
         disconnect();
         return Error::Ok;
       }
+      // Reuse current socket.
+      return Error::Ok;
     } else {
       // Different type. It must be closed.
       close();
@@ -233,6 +236,11 @@ Error NetSocket::tcpListen(int port, NetAddress::Type type, int maxQueuedClients
     return err;
   }
 
+  if (isIpv6()) {
+    int opt = 1;
+    setsockopt(internal_->fd, IPPROTO_IPV6, IPV6_V6ONLY, (char *)&opt, sizeof(opt));
+  }
+
   if (Error err = bind(port); !err) {
     MINIROS_ERROR_NAMED("socket", "NetSocket[%d]::tcpListen() - error binding to port %d: %s", internal_->fd, port, err.toString());
     close();
@@ -267,8 +275,12 @@ Error NetSocket::tcpConnect(const NetAddress& address, bool nonblock)
     setNonBlock();
   }
 
-  if (::connect(internal_->fd, rawAddr, addrLen) != 0) {
+  int fd = internal_->fd;
+  assert(fd != MINIROS_INVALID_SOCKET);
+
+  if (::connect(fd, rawAddr, addrLen) != 0) {
     int err = last_socket_error();
+    const char* errStr = last_socket_error_string();
 
     if (err == EINPROGRESS && internal_->nonblock) {
       // This is expected error and connection attempt will be retried later.
@@ -276,16 +288,16 @@ Error NetSocket::tcpConnect(const NetAddress& address, bool nonblock)
       internal_->state = State::Connecting;
       return Error::WouldBlock;
     }
-    // Close socket on error
-    close();
 
     // Map timeout error if applicable
     if (err == ETIMEDOUT) {
       return Error::Timeout;
     }
 
-    const char* errStr = last_socket_error_string();
-    MINIROS_ERROR_NAMED("socket", "NetSocket[%d]::tcpConnect() error while connecting TCP socket to %s: %s", internal_->fd, address.str().c_str(), errStr);
+    MINIROS_ERROR_NAMED("socket", "NetSocket[%d]::tcpConnect() error while connecting TCP socket to %s: %s", fd, address.str().c_str(), errStr);
+
+    // Close socket on error
+    close();
 
     return Error::SystemError;
   }
@@ -380,7 +392,7 @@ Error NetSocket::setNonBlock()
 
   int result = set_non_blocking(internal_->fd);
   if ( result != 0 ) {
-    MINIROS_ERROR_NAMED("socket", "NetSocket[%d]::setNonBlock() failed with error [%d]", internal_->fd, result);
+    LOCAL_ERROR("NetSocket[%d]::setNonBlock() failed with error [%d]", internal_->fd, result);
     return Error::SystemError;
   }
   internal_->nonblock = true;
@@ -803,7 +815,7 @@ void NetSocket::disconnect()
 #else
     int flags = SHUT_RDWR;
 #endif
-    shutdown(internal_->fd, flags);
+    ::shutdown(internal_->fd, flags);
     internal_->state = State::Initial;
   }
 }

--- a/src/rosconsole/console.cpp
+++ b/src/rosconsole/console.cpp
@@ -838,6 +838,8 @@ void print(FilterBase* filter, void* logger_handle, Level level,
   g_printing_thread_id = std::thread::id();
 }
 
+// Collection of all log locations.
+// Every macro invocation MINIROS_LOG* registers inside this container.
 std::vector<LogLocation*> g_log_locations;
 std::mutex g_locations_mutex;
 

--- a/src/rosconsole/console.cpp
+++ b/src/rosconsole/console.cpp
@@ -35,6 +35,8 @@
 /* Author: Ryan Luna, Ioan Sucan */
 
 #include "miniros/console.h"
+
+#include "common.h"
 #include "console_impl.h"
 #include "miniros/platform.h"
 #include "miniros/rostime.h"
@@ -407,6 +409,15 @@ struct ThreadToken : public Token
   }
 };
 
+struct NiceThreadToken : public Token
+{
+  virtual std::string getString(void*, console::Level, const char*, const char*, const char*, int)
+  {
+    return getThreadName();
+  }
+};
+
+
 struct LoggerToken : public Token
 {
   virtual std::string getString(void* logger_handle, console::Level level, const char* str, const char* file, const char* function, int line)
@@ -485,6 +496,10 @@ TokenPtr createTokenFromType(const std::string& type)
   else if (type == "thread")
   {
     return TokenPtr(std::make_shared<ThreadToken>());
+  }
+  else if (type == "nthread")
+  {
+    return TokenPtr(std::make_shared<NiceThreadToken>());
   }
   else if (type == "logger")
   {

--- a/src/roscore/discovery.cpp
+++ b/src/roscore/discovery.cpp
@@ -211,13 +211,17 @@ void Discovery::Internal::onSocketEvent(network::NetSocket& s, int role, int eve
     return;
   }
 
+  if (packet.uuid == uuid) {
+    // This is our own packet.
+    return;
+  }
+
   discoveryEvent.uuid = packet.uuid;
   discoveryEvent.version = packet.version;
   discoveryEvent.masterUri.scheme = "http://";
   discoveryEvent.masterUri.port = packet.masterPort;
   discoveryEvent.masterUri.host = masterAddr.address;
 
-  MINIROS_INFO("Got broadcast from %s", discoveryEvent.masterUri.host.c_str());
   if (callback) {
     callback(discoveryEvent);
   }

--- a/src/roscore/discovery.cpp
+++ b/src/roscore/discovery.cpp
@@ -267,7 +267,7 @@ Error Discovery::start(PollSet* pollSet, const UUID& uuid, const network::URL& r
   auto rpcAddr = network::NetAddress::fromURL(rpcUrl);
   if (!rpcAddr.valid()) {
     MINIROS_ERROR("Failed to get address for RPC URL=%s", rpcUrl.str().c_str());
-    return Error::InvalidAddress;
+    return Error::InvalidValue;
   }
   internal_->rpcAddress = rpcAddr;
   internal_->broadcastAddr = network::NetAddress::fromIp4String("255.255.255.255", internal_->broadcastPort);

--- a/src/roscore/miniroscore.cpp
+++ b/src/roscore/miniroscore.cpp
@@ -56,6 +56,7 @@ public:
     std::ofstream out(file);
     if (!out.is_open()) {
       std::cerr << "Failed to open PID file \"" << file << "\"" << std::endl;
+      return false;
     }
     out << getpid();
     out.close();

--- a/src/roscore/node_ref.cpp
+++ b/src/roscore/node_ref.cpp
@@ -233,7 +233,7 @@ std::shared_ptr<http::HttpClient> NodeRef::makeClient(PollSet* ps)
   std::weak_ptr<NodeRef> wnode = weak_from_this();
   std::weak_ptr<http::HttpClient> wclient;
   client->setDisconnectHandler(
-    [wnode, wclient](std::shared_ptr<network::NetSocket> socket, http::HttpClient::State state)
+    [wnode, wclient](std::shared_ptr<network::NetSocket> socket, http::HttpClient::State state, Error err)
     {
       if (auto node = wnode.lock()) {
         node->handleDisconnect(wclient);
@@ -325,10 +325,7 @@ void NodeRef::handleDisconnect(const std::weak_ptr<http::HttpClient>& wclient)
 
 void NodeRef::deactivateConnectionUnsafe()
 {
-  if (m_client) {
-    m_client->release();
-    m_client.reset();
-  }
+  m_client.reset();
   m_reqGetPid.reset();
   m_reqShutdown.reset();
   m_activeRequests.clear();

--- a/src/transport/master_link.cpp
+++ b/src/transport/master_link.cpp
@@ -36,6 +36,7 @@
 
 #include "http/http_client.h"
 #include "http/xmlrpc_request.h"
+#include "internal/at_exit.h"
 #include "internal/profiling.h"
 #include "internal/xml_tools.h"
 #include "miniros/names.h"
@@ -264,6 +265,9 @@ Error MasterLink::execute(const std::string& method, const RpcValue& request, Rp
     LOCAL_ERROR("[%s] - failed make connection to host=\"%s:%d\"", method.c_str(), master_host.c_str(), master_port);
     return Error::InvalidURI;
   }
+  AtExit atExit([c, manager]() {
+    manager->releaseXMLRPCClient(c);
+  });
   // TODO: Use local PollSet to spin events. It will prevent some potential deadlocks
   // and help with standalone operation of MasterLink without fully initialized RPC manager.
   bool printed = false;
@@ -277,7 +281,7 @@ Error MasterLink::execute(const std::string& method, const RpcValue& request, Rp
   auto req = http::makeRequest("/RPC2", method);
   req->setParamArray(request);
   std::string reqName = req->debugName();
-  req->onCompleteRaw = [state, c, reqName](Error err, const RpcValue& rawResponse, bool ok_) {
+  req->onCompleteRaw = [state, reqName](Error err, const RpcValue& rawResponse, bool ok_) {
     if (state.use_count() == 1) {
       LOCAL_WARN("MasterLink::execute - unexpected response for request %s after %fs", reqName.c_str(), state->elapsed().toSec());
     } else {

--- a/src/transport/rpc_manager.cpp
+++ b/src/transport/rpc_manager.cpp
@@ -280,10 +280,6 @@ void RPCManager::shutdown()
   // kill the last few clients that were started in the shutdown process
   {
     std::scoped_lock<std::mutex> lock(internal_->clients_mutex_);
-    for (auto& [key, client]: internal_->clients_)
-    {
-      client->release();
-    }
     internal_->clients_.clear();
   }
 
@@ -357,7 +353,7 @@ std::shared_ptr<http::HttpClient> RPCManager::getXMLRPCClient(const std::string 
   auto client = std::make_shared<http::HttpClient>(internal_->poll_set_);
   int reconnectTimeoutMs = 500;
   client->setDisconnectHandler(
-    [wclient = std::weak_ptr(client), reconnectTimeoutMs](std::shared_ptr<network::NetSocket>& socket, http::HttpClient::State state)
+    [wclient = std::weak_ptr(client), reconnectTimeoutMs](std::shared_ptr<network::NetSocket>& socket, http::HttpClient::State state, Error err)
     {
       auto client = wclient.lock();
       if (client && client->getReconnectAttempts() < 10 && client->getQueuedRequests() > 0) {

--- a/src/transport/rpc_manager.cpp
+++ b/src/transport/rpc_manager.cpp
@@ -245,6 +245,14 @@ Error RPCManager::start(const CallbackQueuePtr& cb, int port)
   internal_->http_server_->registerEndpoint(std::make_unique<http::SimpleFilter>(http::HttpMethod::Post, "/RPC2"), xmlrpc_enpoint, cb);
 
   if (Error err = internal_->http_server_->start(port); !err) {
+    MINIROS_ERROR("Failed to start ipv4 RPC server");
+    internal_->http_server_->stop();
+    return err;
+  }
+
+  if (Error err = internal_->http_server_->start6(port); !err) {
+    MINIROS_ERROR("Failed to start ipv6 RPC server");
+    internal_->http_server_->stop();
     return err;
   }
 
@@ -353,11 +361,16 @@ std::shared_ptr<http::HttpClient> RPCManager::getXMLRPCClient(const std::string 
   auto client = std::make_shared<http::HttpClient>(internal_->poll_set_);
   int reconnectTimeoutMs = 500;
   client->setDisconnectHandler(
-    [wclient = std::weak_ptr(client), reconnectTimeoutMs](std::shared_ptr<network::NetSocket>& socket, http::HttpClient::State state, Error err)
+    [wclient = std::weak_ptr(client), reconnectTimeoutMs](std::shared_ptr<network::NetSocket>& socket, http::HttpClient::State state, Error disconnectErr)
     {
       auto client = wclient.lock();
-      if (client && client->getReconnectAttempts() < 10 && client->getQueuedRequests() > 0) {
-        client->reconnect(reconnectTimeoutMs);
+      if (client && client->getQueuedRequests() > 0) {
+        if (Error err = client->reconnect(reconnectTimeoutMs); !err) {
+          LOCAL_ERROR("RPCManager:: failed to initiate reconnect for cached client: %s", err.toString());
+        }
+      } else {
+        // Nothing to do here. These clients are used by MasterLink::execute.
+        // Its logic will deal with timeouts during connection attempts.
       }
     });
   client->setIdleTimeoutHandler(internal_->clientIdleTimeoutMs,
@@ -388,8 +401,7 @@ void RPCManager::releaseXMLRPCClient(std::shared_ptr<http::HttpClient> c)
 {
   if (!internal_)
     return;
-  // TODO: Put client on timeout.
-  // In case of "idle" state it should disconnect itself and remove it from RPC manager.
+
   std::scoped_lock<std::mutex> lock(internal_->clients_mutex_);
   auto rootUrl = c->getRootURL("http://");
   
@@ -412,8 +424,12 @@ void RPCManager::releaseXMLRPCClient(std::shared_ptr<http::HttpClient> c)
   }
 
   if (it != internal_->clients_.end()) {
-    MINIROS_INFO("RPCManager::releaseXMLRPCClient dropping stale client to %s fd=%d", rootUrl.str().c_str(), c->fd());
-    internal_->clients_.erase(it);
+    http::HttpClient::State state = c->getState();
+    if (state != http::HttpClient::State::Idle) {
+      // State::Idle = reuse, other states = delete.
+      MINIROS_INFO("RPCManager::releaseXMLRPCClient dropping stale client to %s fd=%d", rootUrl.str().c_str(), c->fd());
+      internal_->clients_.erase(it);
+    }
   }
 }
 

--- a/test/roscpp/advanced/CMakeLists.txt
+++ b/test/roscpp/advanced/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${MINIROS_GENERATED_INCLUDE_DIRS})
 
 link_directories(${GTEST_LIBRARY_DIRS})
 
-add_test(NAME start-master COMMAND manage-master start)
+#add_test(NAME start-master COMMAND manage-master start)
 #add_test(NAME stop-master COMMAND manage-master stop)
 
 # Advanced tests depend on running rosmaster.
@@ -203,8 +203,8 @@ miniros_add_test(${TEST_GROUP}-publisher_rate SOURCES publisher_rate.cpp WITH_MA
 miniros_add_test(${TEST_GROUP}-subscriber SOURCES subscriber.cpp WITH_MASTER DISABLED)
 #add_dependencies(${TEST_GROUP}-subscriber ${std_msgs_EXPORTED_TARGETS})
 
-
-set_tests_properties(start-master PROPERTIES FIXTURES_REQUIRED "stop-master ${TESTS_WITH_MASTER}")
+# Master is started and stopped by github script
+#set_tests_properties(start-master PROPERTIES FIXTURES_REQUIRED "stop-master ${TESTS_WITH_MASTER}")
 #set_tests_properties(stop-master PROPERTIES FIXTURES_CLEANUP "${TESTS_WITH_MASTER}")
 
 message(STATUS "Advanced tests with master: ${TESTS_WITH_MASTER}")

--- a/test/roscpp/advanced/params.cpp
+++ b/test/roscpp/advanced/params.cpp
@@ -593,10 +593,23 @@ int main(int argc, char** argv)
   // These parameters were set by a rostest/roslaunch.
   // We set these manually to mimic behaviour of original test without roslaunch.
   auto master = miniros::getMasterLink();
-  master->set("string", "test");
-  master->set("int", 10);
-  master->set("double", 10.5);
-  master->set("bool", false);
+  if (!master->set("string", "test"))
+    return EXIT_FAILURE;
+  if (!master->set("int", 10))
+    return EXIT_FAILURE;
+  if (!master->set("double", 10.5))
+    return EXIT_FAILURE;
+  if (!master->set("bool", false))
+    return EXIT_FAILURE;
+
+  // Clean up parameters left from previous test run.
+  master->del("test_set_param_setThenGetStringCached");
+  master->del("test_set_param_setThenGetStringCachedNodeHandle");
+  master->del("test_set_param_setThenGetStringCached2");
+  master->del("/a/b/c/d/e/f/s_c");
+  master->del("/a/b/c/d/e/f/s_b");
+  master->del("/s_b");
+  master->del("/s_c");
 
   miniros::NodeHandle nh;
 

--- a/test/roscpp/advanced/params.cpp
+++ b/test/roscpp/advanced/params.cpp
@@ -583,10 +583,9 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   miniros::handleCrashes();
-  miniros::console::set_logger_level("destructor", console::Level::Debug);
   miniros::console::set_logger_level("miniros.http", console::Level::Debug);
-  miniros::console::set_logger_level("poll_set", console::Level::Debug);
-  miniros::console::set_logger_level("net", console::Level::Debug);
+  miniros::console::set_logger_level("miniros.poll_set", console::Level::Debug);
+  miniros::console::set_logger_level("miniros.net", console::Level::Debug);
 
   miniros::init(argc, argv, "params");
 

--- a/test/roscpp/advanced/params.cpp
+++ b/test/roscpp/advanced/params.cpp
@@ -582,6 +582,12 @@ TEST(Params, getParamCachedSetParamLoop) {
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
+  miniros::handleCrashes();
+  miniros::console::set_logger_level("destructor", console::Level::Debug);
+  miniros::console::set_logger_level("miniros.http", console::Level::Debug);
+  miniros::console::set_logger_level("poll_set", console::Level::Debug);
+  miniros::console::set_logger_level("net", console::Level::Debug);
+
   miniros::init(argc, argv, "params");
 
   // These parameters were set by a rostest/roslaunch.

--- a/test/roscpp/basic/test_http.cpp
+++ b/test/roscpp/basic/test_http.cpp
@@ -575,7 +575,7 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   miniros::handleCrashes();
-
+  miniros::setThreadName("main");
   miniros::console::set_logger_level("destructor", console::Level::Debug);
   miniros::console::set_logger_level("miniros.http", console::Level::Debug);
   miniros::console::set_logger_level("miniros.poll_set", console::Level::Debug);

--- a/test/roscpp/basic/test_http.cpp
+++ b/test/roscpp/basic/test_http.cpp
@@ -575,8 +575,11 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   miniros::handleCrashes();
+
   miniros::console::set_logger_level("destructor", console::Level::Debug);
   miniros::console::set_logger_level("miniros.http", console::Level::Debug);
   miniros::console::set_logger_level("poll_set", console::Level::Debug);
+  miniros::console::set_logger_level("net", console::Level::Debug);
+
   return RUN_ALL_TESTS();
 }

--- a/test/roscpp/basic/test_http.cpp
+++ b/test/roscpp/basic/test_http.cpp
@@ -65,7 +65,7 @@ public:
     Error err = server_->start(0);
     ASSERT_EQ(err, Error::Ok);
     watchdog_ = std::make_unique<Watchdog>(SIGQUIT);
-    watchdog_->watch(10000);
+    //watchdog_->watch(10000);
   }
 
   void TearDown() override
@@ -106,25 +106,65 @@ constexpr double responseTimeoutSec = 50;
 
 TEST(BasicSanity, WaitIsReal)
 {
+  // Verify that request.waitingForResponse is actually waiting and spending some time.
   http::HttpRequest emptyRequest;
 
   auto start = SteadyTime::now();
   WallDuration waitDuration{0.5};
   emptyRequest.waitForResponse(waitDuration);
   WallDuration elapsed = SteadyTime::now() - start;
-  /// Expecting it to actually wait.
+  // Expecting it to actually wait.
   ASSERT_GE(elapsed, waitDuration*0.5)
       << "It seems condition_variable::wait_for does not properly wait." << std::endl
       << " It can be caused by missing proper implementation for std threads " << std::endl;
 }
 
-TEST_F(HttpServerTest, ConnectNoServer)
+TEST_F(HttpServerTest, ConnectNoServerWithReconnects)
 {
   http::HttpClient client(&poll_manager_.getPollSet());
 
-  client.connect("127.0.0.1", 19999);
-  Error conErr = client.waitConnected(WallDuration(connectionTimeoutSec));
-  EXPECT_EQ(conErr, Error::NotConnected);
+  std::atomic_int32_t reconnects = 0;
+  client.setDisconnectHandler([&reconnects, &client](std::shared_ptr<network::NetSocket>& socket, http::HttpClient::State state, Error err) {
+    ++reconnects;
+    EXPECT_EQ(err, Error::ConnectionRefused);
+    client.reconnect(50);
+  });
+
+  Error connectErr = client.connect("127.0.0.1", 19999);
+  ASSERT_EQ(connectErr, Error::Ok);
+  Error waitErr = client.waitConnected(WallDuration(1, 0));
+  // There should be about ~20 reconnects (1.0 / 0.05 = 20).
+  // This test will blink only if there is a serious CPU load.
+  EXPECT_GE(reconnects.load(), 10);
+
+  // Forcibly shut down thread before client is destroyed.
+  poll_manager_.shutdown();
+}
+
+TEST_F(HttpServerTest, ConnectInvalidHostnameWithReconnects)
+{
+  // Connecting client to unknown hostname.
+  // Client should keep retrying connection with hopes that someone provides proper IP for that hostname later.
+  http::HttpClient client(&poll_manager_.getPollSet());
+
+  std::atomic_int32_t disconnects = 0;
+  client.setDisconnectHandler([&disconnects, &client](std::shared_ptr<network::NetSocket>& socket, http::HttpClient::State state, Error err) {
+    ++disconnects;
+    EXPECT_EQ(err, Error::AddressIsUnknown);
+    client.reconnect(50);
+  });
+
+  // Expecting that connect returns Ok, and disconnect handler will be called exactly once.
+  Error err = client.connect("certainly_unknown_hostname_123456", 19999);
+  ASSERT_EQ(err, Error::Ok);
+  ASSERT_EQ(disconnects, 1);
+
+  // Expect more attempts to get address.
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_GE(disconnects, 1);
+
+  // Forcibly shut down thread before client is destroyed.
+  poll_manager_.shutdown();
 }
 
 TEST_F(HttpServerTest, SimpleGet)
@@ -535,8 +575,8 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   miniros::handleCrashes();
-
   miniros::console::set_logger_level("destructor", console::Level::Debug);
   miniros::console::set_logger_level("miniros.http", console::Level::Debug);
+  miniros::console::set_logger_level("poll_set", console::Level::Debug);
   return RUN_ALL_TESTS();
 }

--- a/test/roscpp/basic/test_http.cpp
+++ b/test/roscpp/basic/test_http.cpp
@@ -65,7 +65,7 @@ public:
     Error err = server_->start(0);
     ASSERT_EQ(err, Error::Ok);
     watchdog_ = std::make_unique<Watchdog>(SIGQUIT);
-    //watchdog_->watch(10000);
+    watchdog_->watch(50000);
   }
 
   void TearDown() override

--- a/test/roscpp/basic/test_http.cpp
+++ b/test/roscpp/basic/test_http.cpp
@@ -578,8 +578,8 @@ int main(int argc, char** argv)
 
   miniros::console::set_logger_level("destructor", console::Level::Debug);
   miniros::console::set_logger_level("miniros.http", console::Level::Debug);
-  miniros::console::set_logger_level("poll_set", console::Level::Debug);
-  miniros::console::set_logger_level("net", console::Level::Debug);
+  miniros::console::set_logger_level("miniros.poll_set", console::Level::Debug);
+  miniros::console::set_logger_level("miniros.net", console::Level::Debug);
 
   return RUN_ALL_TESTS();
 }

--- a/test/roscpp/basic/test_net.cpp
+++ b/test/roscpp/basic/test_net.cpp
@@ -32,6 +32,20 @@ TEST(Address, ip4)
   EXPECT_EQ(address3.type(), NetAddress::AddressInvalid);
 }
 
+TEST(Address, invalidAddress)
+{
+  NetAddress address;
+  // Check completely invalid address.
+  Error err = addressFromString(NetAddress::AddressIPv4, "1235132525233421234_235^232147", 123456, address);
+  EXPECT_EQ(err, Error::InvalidValue);
+  ASSERT_FALSE(address.valid());
+
+  // Check some valid hostname with just an unknown IP.
+  Error err2 = addressFromString(NetAddress::AddressIPv4, "nice_but_not_known", 1234, address);
+  EXPECT_EQ(err2, Error::AddressIsUnknown);
+  EXPECT_FALSE(address.valid());
+}
+
 TEST(Address, ip6)
 {
   NetAddress address1 = NetAddress::fromIp6String("fe80::1ff:fe23:4567:890a", 10);
@@ -57,9 +71,13 @@ TEST(Adapters, SameNet)
   NetAdapter adapter;
 
   adapter.address = NetAddress::fromIp4String("192.168.1.10", 0);
+  ASSERT_EQ(adapter.address.type(), NetAddress::AddressIPv4);
   adapter.mask = NetAddress::fromIp4String("255.255.255.0", 0);
+  ASSERT_EQ(adapter.mask.type(), NetAddress::AddressIPv4);
 
   NetAddress address1 = NetAddress::fromIp4String("192.168.1.11", 13);
+  ASSERT_EQ(address1.type(), NetAddress::AddressIPv4);
+
   EXPECT_TRUE(adapter.matchNetAddress(address1));
 
   NetAddress address2 = NetAddress::fromIp4String("192.168.2.31", 13);


### PR DESCRIPTION
Fixing blinking test with new HTTP client and server

1. Added support for ipv6 in HttpServer.
2. Fixed ipv6 support in RPCManager.
3. Fixed leaking HttpClient and HttpServerConnection instances.
4. Updated docs about loggings
5. Issues with blinking tests, related to HttpClient are fixed.

Resolves: #43 