### PR TITLE
Fix shutdown sequence

### DIFF
--- a/include/miniros/errors.h
+++ b/include/miniros/errors.h
@@ -63,6 +63,8 @@ struct MINIROS_DECL Error {
     ConnectionRefused,
     /// IP address of host is unknown.
     AddressIsUnknown,
+    /// Permission denied during some OS action.
+    PermissionDenied,
   };
 
   Error() :code(Ok)

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -56,6 +56,8 @@ const char* Error::toString() const {
       return "Connection Refused";
     case Error::AddressIsUnknown:
       return "Address is unknown";
+    case Error::PermissionDenied:
+      return "Permission denied";
   }
   return "Unknown error";
 }

--- a/src/io/poll_manager.cpp
+++ b/src/io/poll_manager.cpp
@@ -91,7 +91,6 @@ void PollManager::threadFunc()
 
   while (!shutting_down_)
   {
-
     {
       std::scoped_lock<PollWatchers> lock(poll_watchers_);
       auto it = poll_watchers_.begin();
@@ -106,9 +105,6 @@ void PollManager::threadFunc()
     {
       break;
     }
-
-    // While it breaks abstraction, it reduces number of mutexes and threading challenges.
-    checkForShutdown();
 
     constexpr int updatePeriodMS = 50;
 

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -212,8 +212,15 @@ Error NetSocket::tcpSocket(NetAddress::Type type)
   }
   int fd = socket(addrType, SOCK_STREAM, IPPROTO_TCP);
   if (fd < 0) {
-    const char* err = last_socket_error_string();
-    MINIROS_ERROR_NAMED("socket", "NetSocket::tcpListen() - error while trying to create listening socket: %s", err);
+    int err = errno;
+    if (err == EAFNOSUPPORT || err == EPROTONOSUPPORT)
+      return Error::NotSupported;
+    if (err == ENOMEM)
+      return Error::OutOfMemory;
+    if (err == EACCES)
+      return Error::PermissionDenied;
+    const char* errMsg = last_socket_error_string();
+    MINIROS_ERROR_NAMED("socket", "NetSocket::tcpListen() - error while trying to create listening socket: %s", errMsg);
     return Error::SystemError;
   }
   internal_->fd = fd;

--- a/src/replacements/program_options/command_line.cpp
+++ b/src/replacements/program_options/command_line.cpp
@@ -193,8 +193,7 @@ std::vector<option> command_line_parser::run_impl()
             // This option may grab some more tokens.
             // We only allow to grab tokens that are not already
             // recognized as key options.
-
-            int can_take_more = max_tokens - static_cast<int>(opt.value.size());
+            unsigned can_take_more = max_tokens - static_cast<unsigned>(opt.value.size());
             unsigned j = i+1;
             for (; can_take_more && j < result.size(); --can_take_more, ++j)
             {
@@ -202,9 +201,9 @@ std::vector<option> command_line_parser::run_impl()
                 if (!opt2.string_key.empty())
                     break;
 
-                if (opt2.position_key == INT_MAX)
+                if (opt2.position_key == -1)
                 {
-                    // We use INT_MAX to mark positional options that
+                    // We use -1 ~~INT_MAX~~ to mark positional options that
                     // were found after the '--' terminator and therefore
                     // should stay positional forever.
                     break;

--- a/src/transport/init.cpp
+++ b/src/transport/init.cpp
@@ -59,6 +59,7 @@
 
 // Needed to set IPv6 flag inside XmlRpcSocket.
 #include "internal/profiling.h"
+#include "rosconsole/local_log.h"
 #include "xmlrpcpp/XmlRpcSocket.h"
 
 #include <miniros/console.h>
@@ -94,7 +95,6 @@ void init(const M_string& remappings);
 
 CallbackQueuePtr g_global_queue;
 std::atomic<ROSOutAppender*> g_rosout_appender = nullptr;
-static CallbackQueuePtr g_internal_callback_queue;
 
 static bool g_initialized = false;
 static bool g_started = false;
@@ -104,11 +104,43 @@ static std::atomic_bool g_ok = false;
 static uint32_t g_init_options = 0;
 static std::atomic_bool g_shutdown_requested = false;
 static std::atomic_bool g_shutting_down = false;
-static std::recursive_mutex g_shutting_down_mutex;
-static std::thread g_internal_queue_thread;
-static MasterLinkPtr g_master_link;
 
-void shutdownLocked(std::unique_lock<std::recursive_mutex>& lock);
+/// Executor deals with shutdown sequence from background thread.
+class InternalCallbackKeeper : public CallbackInterface {
+public:
+  ~InternalCallbackKeeper() override
+  {
+    stop();
+  }
+
+  CallResult call() override;
+
+  /// Start internal thread for processing callback queue.
+  void start();
+
+  /// Stop internal thread for processing callback queue.
+  bool stop();
+
+  void requestShutdown();
+
+  CallbackQueuePtr getInternalCallbackQueue();
+
+  void shutdownLocked(std::unique_lock<std::recursive_mutex>& lock);
+
+  std::recursive_mutex shutting_down_mutex_;
+
+protected:
+  /// Thread function for callback queue.
+  void threadFunc();
+
+  std::thread internal_queue_thread_;
+  CallbackQueuePtr internal_callback_queue_;
+  std::atomic_bool stop_internal_queue_ = false;
+};
+
+static std::shared_ptr<InternalCallbackKeeper> g_shutdown_keeper = std::make_shared<InternalCallbackKeeper>();
+
+static MasterLinkPtr g_master_link;
 
 bool isInitialized()
 {
@@ -120,35 +152,9 @@ bool isShuttingDown()
   return g_shutting_down;
 }
 
-void checkForShutdown()
-{
-  if (g_shutdown_requested)
-  {
-    // Since this gets run from within a mutex inside PollManager, we need to prevent ourselves from deadlocking with
-    // another thread that's already in the middle of shutdown()
-
-    std::unique_lock<std::recursive_mutex> lock(g_shutting_down_mutex, std::defer_lock);
-
-    while (!lock.try_lock() && !g_shutting_down)
-    {
-      miniros::WallDuration(0.001).sleep();
-    }
-
-    if (!g_shutting_down)
-    {
-      shutdownLocked(lock);
-      MINIROS_INFO("Shutdown procedure is complete");
-    } else {
-      MINIROS_WARN("Shutdown procedure was missed");
-    }
-
-    g_shutdown_requested = false;
-  }
-}
-
 void requestShutdown()
 {
-  g_shutdown_requested = true;
+  g_shutdown_keeper->requestShutdown();
 }
 
 void atexitCallback()
@@ -266,12 +272,7 @@ void clockCallback(const rosgraph_msgs::Clock::ConstPtr& msg)
 
 CallbackQueuePtr getInternalCallbackQueue()
 {
-  if (!g_internal_callback_queue)
-  {
-    g_internal_callback_queue.reset(new CallbackQueue);
-  }
-
-  return g_internal_callback_queue;
+  return g_shutdown_keeper->getInternalCallbackQueue();
 }
 
 void basicSigintHandler(int sig)
@@ -280,17 +281,6 @@ void basicSigintHandler(int sig)
 
   MINIROS_DEBUG("Got SIGINT. Initiating shutdown");
   miniros::requestShutdown();
-}
-
-void internalCallbackQueueThreadFunc(CallbackQueuePtr queue)
-{
-  setThreadName("ROS::internalCallbackQueue");
-  disableAllSignalsInThisThread();
-
-  while (!g_shutting_down)
-  {
-    queue->callAvailable(WallDuration(0.1));
-  }
 }
 
 bool isStarted()
@@ -442,7 +432,7 @@ Error start()
 
   if (g_shutting_down) goto end;
 
-  g_internal_queue_thread = std::thread(internalCallbackQueueThreadFunc, internalCallbackQueue);
+  g_shutdown_keeper->start();
   getGlobalCallbackQueue()->enable();
 
   MINIROS_DEBUG("Started node [%s], pid [%d], bound on [%s], xmlrpc port [%d], tcpros port [%d], using [%s] time",
@@ -456,7 +446,7 @@ end:
   // If we received a shutdown request while initializing, wait until we've shutdown to continue
   if (g_shutting_down)
   {
-    std::scoped_lock<std::recursive_mutex> lock(g_shutting_down_mutex);
+    std::scoped_lock<std::recursive_mutex> lock(g_shutdown_keeper->shutting_down_mutex_);
   }
 
   auto start_total = SteadyTime::now() - time_start;
@@ -654,7 +644,7 @@ bool ok()
   return g_ok.load(std::memory_order_relaxed);
 }
 
-void shutdownLocked(std::unique_lock<std::recursive_mutex>& lock)
+void InternalCallbackKeeper::shutdownLocked(std::unique_lock<std::recursive_mutex>& lock)
 {
   MINIROS_DEBUG("Running shutdown procedure");
   g_shutting_down = true;
@@ -666,12 +656,6 @@ void shutdownLocked(std::unique_lock<std::recursive_mutex>& lock)
     g_global_queue->clear();
   }
 
-  if (g_internal_queue_thread.get_id() != std::this_thread::get_id())
-  {
-    if (g_internal_queue_thread.joinable())
-      g_internal_queue_thread.join();
-  }
-
   //miniros::console::deregister_appender(g_rosout_appender);
   if (auto rosout_appender = g_rosout_appender.exchange(nullptr)) {
     delete rosout_appender;
@@ -681,10 +665,12 @@ void shutdownLocked(std::unique_lock<std::recursive_mutex>& lock)
   {
     TopicManager::instance()->shutdown();
     ServiceManager::instance()->shutdown();
-    PollManager::instance()->shutdown();
     ConnectionManager::instance()->shutdown();
     RPCManager::instance()->shutdown();
+    PollManager::instance()->shutdown();
   }
+
+  stop();
 
   g_started = false;
   g_ok = false;
@@ -693,11 +679,88 @@ void shutdownLocked(std::unique_lock<std::recursive_mutex>& lock)
 
 void shutdown()
 {
-  std::unique_lock<std::recursive_mutex> lock(g_shutting_down_mutex);
+  std::unique_lock<std::recursive_mutex> lock(g_shutdown_keeper->shutting_down_mutex_);
   if (g_shutting_down) {
     return;
   }
-  shutdownLocked(lock);
+  g_shutdown_keeper->shutdownLocked(lock);
+}
+
+void InternalCallbackKeeper::start()
+{
+  assert(!internal_queue_thread_.joinable());
+  internal_queue_thread_ = std::thread(&InternalCallbackKeeper::threadFunc, this);
+}
+
+bool InternalCallbackKeeper::stop()
+{
+  stop_internal_queue_ = true;
+
+  if (internal_queue_thread_.get_id() == std::this_thread::get_id())
+    return false;
+
+  if (internal_queue_thread_.joinable()) {
+    internal_queue_thread_.join();
+  }
+  return true;
+}
+
+
+void InternalCallbackKeeper::requestShutdown()
+{
+  g_shutdown_requested = true;
+  assert(internal_callback_queue_);
+  internal_callback_queue_->addCallback(g_shutdown_keeper, reinterpret_cast<uint64_t>(g_shutdown_keeper.get()));
+}
+
+CallbackQueuePtr InternalCallbackKeeper::getInternalCallbackQueue()
+{
+  if (!internal_callback_queue_)
+  {
+    internal_callback_queue_.reset(new CallbackQueue);
+  }
+
+  return internal_callback_queue_;
+}
+
+void InternalCallbackKeeper::threadFunc()
+{
+  setThreadName("CallbackQueue");
+  disableAllSignalsInThisThread();
+  assert(internal_callback_queue_);
+
+  while (!stop_internal_queue_ && internal_callback_queue_)
+  {
+    internal_callback_queue_->callAvailable(WallDuration(0.1));
+  }
+}
+
+
+CallbackInterface::CallResult InternalCallbackKeeper::call()
+{
+  if (g_shutdown_requested)
+  {
+    // Since this gets run from within a mutex inside PollManager, we need to prevent ourselves from deadlocking with
+    // another thread that's already in the middle of shutdown()
+
+    std::unique_lock<std::recursive_mutex> lock(shutting_down_mutex_, std::defer_lock);
+
+    while (!lock.try_lock() && !g_shutting_down)
+    {
+      miniros::WallDuration(0.001).sleep();
+    }
+
+    if (!g_shutting_down)
+    {
+      shutdownLocked(lock);
+      MINIROS_INFO("Shutdown procedure is complete");
+    } else {
+      MINIROS_WARN("Shutdown procedure was missed");
+    }
+
+    g_shutdown_requested = false;
+  }
+  return CallResult::Success;
 }
 
 MasterLinkPtr getMasterLink()

--- a/src/transport/master_link.cpp
+++ b/src/transport/master_link.cpp
@@ -330,7 +330,7 @@ Error MasterLink::execute(const std::string& method, const RpcValue& request, Rp
       waitDuration = SteadyTime::now() - waitStart;
     }
 
-    noShutdown = !miniros::isShuttingDown() && !manager->isShuttingDown();
+    noShutdown = !manager->isShuttingDown();
 
     auto s = req->state();
     if (s == http::HttpRequest::State::ClientQueued && noShutdown) {

--- a/src/transport/rpc_manager.cpp
+++ b/src/transport/rpc_manager.cpp
@@ -245,15 +245,19 @@ Error RPCManager::start(const CallbackQueuePtr& cb, int port)
   internal_->http_server_->registerEndpoint(std::make_unique<http::SimpleFilter>(http::HttpMethod::Post, "/RPC2"), xmlrpc_enpoint, cb);
 
   if (Error err = internal_->http_server_->start(port); !err) {
-    MINIROS_ERROR("Failed to start ipv4 RPC server");
+    MINIROS_ERROR("Failed to start ipv4 RPC server: %s", err.toString());
     internal_->http_server_->stop();
     return err;
   }
 
   if (Error err = internal_->http_server_->start6(port); !err) {
-    MINIROS_ERROR("Failed to start ipv6 RPC server");
-    internal_->http_server_->stop();
-    return err;
+    if (err == Error::NotSupported) {
+      MINIROS_WARN("Failed to start ipv6 RPC server - IPv6 is not supported.");
+    } else  {
+      MINIROS_ERROR("Failed to start ipv6 RPC server: %s", err.toString());
+      internal_->http_server_->stop();
+      return err;
+    }
   }
 
   std::string host = network::getHost();


### PR DESCRIPTION
Shutdown processing is moved from PollManager thread into InternalCallbackQueue thread. It allows to run async processing of HttpClient by PollManager and properly execute unsubscription requests through MasterLink


Fixes #89 #43 