### PR TITLE
Fix HTTP request method and topic endpoint status handling

### DIFF
--- a/src/http/http_server_connection.cpp
+++ b/src/http/http_server_connection.cpp
@@ -231,6 +231,7 @@ std::shared_ptr<HttpRequest> HttpServerConnection::makeRequestObject(Lock& lock)
 {
   auto requestObject = std::make_shared<HttpRequest>();
   requestObject->resetResponse();
+  requestObject->setMethod(http_frame_.requestMethod);
   requestObject->setPath(std::string{http_frame_.getPath()});
   requestObject->setRequestBody(std::string{http_frame_.body()});
 

--- a/src/roscore/master_endpoints.cpp
+++ b/src/roscore/master_endpoints.cpp
@@ -63,7 +63,7 @@ Error TopicInfoEndpoint::handle(const network::ClientInfo& clientInfo, std::shar
 
   std::string body = "<!doctype html><html><title>Mini ROS master</title><body>";
 
-  if (name.empty() || internal->renderTopicInfo(name, body)) {
+  if (name.empty() || !internal->renderTopicInfo(name, body)) {
     request->setResponseStatus(404, "Topic not found");
   } else {
     request->setResponseStatusOk();

--- a/src/roscore/master_html_printers.cpp
+++ b/src/roscore/master_html_printers.cpp
@@ -62,13 +62,30 @@ void Master::Internal::renderMasterStatus(std::string& output) const
 
 Error Master::Internal::renderTopicInfo(const std::string_view& name, std::string& output) const
 {
-  std::stringstream ss;
-
   std::string type = regManager.getTopicType(name);
-  ss << "<p>" << print::HB(name) << " ";
+  const bool hasType = !type.empty();
 
-  if (type.empty())
+  std::vector<std::shared_ptr<NodeRef>> publishers;
+  size_t numPubs = regManager.iteratePublishers(name, [&](const std::shared_ptr<NodeRef>& node) {
+    publishers.push_back(node);
+    return true;
+  });
+
+  std::vector<std::shared_ptr<NodeRef>> subscribers;
+  size_t numSubs = regManager.iterateSubscribers(name, [&](const std::shared_ptr<NodeRef>& node) {
+    subscribers.push_back(node);
+    return true;
+  });
+
+  if (!hasType && numPubs == 0 && numSubs == 0) {
+    return Error::FileNotFound;
+  }
+
+  if (!hasType)
     type = "unknown";
+
+  std::stringstream ss;
+  ss << "<p>" << print::HB(name) << " ";
   ss << "(" << type << ")";
   ss << "</p>" << std::endl;
 
@@ -77,14 +94,13 @@ Error Master::Internal::renderTopicInfo(const std::string_view& name, std::strin
   //  - node2
   ss << "<p>" << print::HB("Publishers: ") << std::endl;
   ss << "<ul>";
-  size_t numPubs = regManager.iteratePublishers(name, [&](const std::shared_ptr<NodeRef>& node) {
+  for (const std::shared_ptr<NodeRef>& node: publishers) {
     const std::string& name = node->id();
     std::string url = node->getApi();
     ss << "<li>";
     ss << print::PrefixUrl("/node", name, name) << ": " << print::Url(url, url);
     ss << "</li>";
-    return true;
-  });
+  }
   ss << "</ul>";
   if (!numPubs) {
     ss << "none" << std::endl;
@@ -96,14 +112,13 @@ Error Master::Internal::renderTopicInfo(const std::string_view& name, std::strin
   //  - node2
   ss << "<p>" << print::HB("Subscribers: ") << std::endl;
   ss << "<ul>";
-  size_t numSubs = regManager.iterateSubscribers(name, [&](const std::shared_ptr<NodeRef>& node) {
+  for (const std::shared_ptr<NodeRef>& node: subscribers) {
     const std::string& name = node->id();
     std::string url = node->getApi();
     ss << "<li>";
     ss << print::PrefixUrl("/node", name, name) << ": " << print::Url(url, url);
     ss << "</li>";
-    return true;
-  });
+  }
   ss << "</ul>";
   if (!numSubs) {
     ss << "none" << std::endl;

--- a/test/roscpp/basic/test_http.cpp
+++ b/test/roscpp/basic/test_http.cpp
@@ -245,6 +245,7 @@ class JsonPostEndpointHandler : public http::EndpointHandler {
 public:
   Error handle(const network::ClientInfo& clientInfo, std::shared_ptr<http::HttpRequest> request) override
   {
+    EXPECT_EQ(request->method(), http::HttpMethod::Post);
 
     // Read JSON from request body
     std::string_view requestBody = request->requestBody();

--- a/test/rostime/test_time.cpp
+++ b/test/rostime/test_time.cpp
@@ -28,6 +28,7 @@
  */
 
 #include <vector>
+#include <iomanip>
 
 #include <gtest/gtest.h>
 #include <miniros/rate.h>


### PR DESCRIPTION
## Summary

This PR contains three small fixes found while building and checking miniroscpp HTTP/master behavior:

- Add the missing `<iomanip>` include required by `test_time.cpp`.
- Preserve the parsed HTTP request method when constructing server-side `HttpRequest` objects.
- Fix `/topic/...` master HTTP endpoint status handling.

## Details

`test_time.cpp` uses `std::setfill` and `std::setw`, so it needs `<iomanip>` included explicitly.

`HttpServerConnection::makeRequestObject()` now copies the parsed request method from the HTTP parser frame into the created `HttpRequest`. Without this, handlers could receive the default `GET` method even for requests parsed as `POST`.

`TopicInfoEndpoint` now treats `Error::Ok` from `renderTopicInfo()` as success. `renderTopicInfo()` also checks whether a topic is known before rendering its HTML page, matching the `/node/...` behavior more closely:
- existing topic -> `200 OK`
- missing topic -> `404 Topic not found`