### PR TITLE
[roscore] Implementing checks and cleanup for dead nodes

### DIFF
--- a/docs/rosmaster.md
+++ b/docs/rosmaster.md
@@ -1,40 +1,41 @@
 # ROS Master protocol #
 
-## getPublishedTopics ##
+Most of negotiation protocol can be found at:
+ - Master API: https://wiki.ros.org/ROS/Master_API
+ - Slave(Node) API: https://wiki.ros.org/ROS/Slave_API
+ - Parameter API: https://wiki.ros.org/ROS/Parameter%20Server%20API
 
-Provides a list of published topics.
-
-
-req[0] = string this_node::getName()
-req[1] = ""
-
-
-rep: array of:
-    string topic_name, string topic_type
-
-## getSystemState ##
-
-Provides a list of active ROS nodes
-
-req[0] = ownNodeName
-
-rep[] - array of structs 
-TODO: Continue this.
+**MiniROS** follows exactly the same protocol to keep compatibility with original ROS1.
+While some additional API calls can be added to **miniroscore** and used by miniros-based nodes, it still must be compatible with any ROS1 client. 
 
 
-## setParam ##
+# Internals #
 
-Sets value on rosparam server
+Node is uniquely defined by its name and URI. There should be only one active node with the same name.
+If some new node with the same name arrives, then old node must be closed.
 
-Request = {
-    string ownNodeName;
-    string key;
-    RpcValue value;
-}
+# RegistrationManager #
 
-## loopupNode ##
+Information about nodes and topics is stored at `RegistrationManager`.
+It stores both mapping between topics, services and corresponding NodeRef references, and a collection of NodeRef objects themselves.
 
-# Node XMLRPC protocol #
+Nodes queued in `m_nodesToShutdown` are processed by `Master::update()`: Master may send a Slave API
+`shutdown` request if the HTTP connection is still usable, drops the node's registrations, and notifies
+remaining subscribers via `publisherUpdate` for topics the node used to publish.
 
-## getSubscriptions ##
+# NodeRef #
 
+It provides both a collection of information about the node, and an interface to interact with this node.
+
+When a node registers publishers/subscribers/services, Master opens an HTTP client to the node's Slave API
+and requests `getPid`. The PID is stored for diagnostics only — Master never signals the OS process.
+
+Liveness and cleanup:
+
+1. **On disconnect** — Master attempts to reconnect. If reconnect fails, the node is marked `Dead`.
+2. **Periodic probe** — `Master::update()` periodically re-sends `getPid` to verify the Slave API is reachable.
+3. **Shutdown queue** — Dead / superseded nodes are placed into `RegistrationManager::m_nodesToShutdown`.
+   Processing that queue drops registrations and notifies remaining nodes about updated publications.
+
+The check period is configured with the `--node_check_period` option of `miniroscore` (seconds; `0` disables
+periodic checks). Default is 5 seconds.

--- a/src/roscore/master.cpp
+++ b/src/roscore/master.cpp
@@ -22,6 +22,7 @@
 #include "miniros/http/endpoints/filesystem.h"
 #include "miniros/http/http_filters.h"
 #include "miniros/callback_queue.h"
+#include "miniros/rostime.h"
 
 namespace miniros {
 
@@ -231,16 +232,100 @@ void Master::setResolveNodeIP(bool resolv)
   internal_->parameterStorage.setParam("master", "/resolve_ip", resolv);
 }
 
+void Master::setNodeCheckPeriod(double seconds)
+{
+  if (!internal_)
+    return;
+  if (seconds < 0)
+    seconds = 0;
+  internal_->nodeCheckPeriod = WallDuration(seconds);
+  internal_->lastNodeCheck = SteadyTime();
+  MINIROS_INFO("Node liveness check period set to %.3fs%s",
+               seconds, seconds <= 0 ? " (disabled)" : "");
+}
+
+void Master::Internal::checkNodesAlive()
+{
+  auto nodes = regManager.listAllNodes();
+  for (const std::shared_ptr<NodeRef>& node : nodes) {
+    if (!node)
+      continue;
+
+    if (node->isLocal())
+      continue;
+
+    if (node->getState() == NodeRef::State::Dead) {
+      regManager.scheduleShutdown(node);
+      continue;
+    }
+
+    if (!node->needRequests())
+      continue;
+
+    // Refresh PID / probe reachability via Slave API.
+    if (Error err = node->sendGetPid("/master"); !err) {
+      // NotConnected is expected while reconnecting; disconnect handler marks
+      // the node Dead when reconnect fails, then scheduleDeadNodesForShutdown
+      // picks it up.
+      MINIROS_DEBUG("sendGetPid(%s) returned %s", node->id().c_str(), err.toString());
+    }
+  }
+}
+
+void Master::Internal::shutdownNode(const std::shared_ptr<NodeRef>& node, const std::string& reason)
+{
+  assert(node);
+  if (!node)
+    return;
+
+  std::set<std::string> publishedTopics;
+  {
+    node->lock();
+    publishedTopics = node->getPublicationsUnsafe();
+    node->unlock();
+  }
+
+  // Ask the node to shut down if the HTTP client is still usable.
+  if (Error err = node->sendShutdown(reason); !err) {
+    MINIROS_DEBUG("sendShutdown(%s) returned %s", node->id().c_str(), err.toString());
+  }
+
+  regManager.dropRegistrations(*node);
+  node->clear();
+
+  // Tell remaining subscribers that publishers for these topics have changed.
+  for (const std::string& topic : publishedTopics) {
+    auto subscribers = regManager.getTopicSubscribers(topic);
+    handler.notifyTopicSubscribers(topic, subscribers);
+  }
+
+  node->markDead();
+}
+
 void Master::update()
 {
-  auto shutdownNodes = internal_->regManager.pullShutdownNodes();
+  // Queue unreachable nodes discovered via disconnect / failed reconnect.
+  internal_->regManager.scheduleDeadNodesForShutdown();
 
-  for (std::shared_ptr<NodeRef> nr: shutdownNodes) {
-    RpcValue msg;
+  if (internal_->nodeCheckPeriod.toSec() > 0) {
+    const SteadyTime now = SteadyTime::now();
+    if (internal_->lastNodeCheck.isZero() ||
+        (now - internal_->lastNodeCheck) >= internal_->nodeCheckPeriod) {
+      internal_->lastNodeCheck = now;
+      internal_->checkNodesAlive();
+    }
+  }
+
+  auto shutdownNodes = internal_->regManager.pullShutdownNodes();
+  for (std::shared_ptr<NodeRef> nr : shutdownNodes) {
     std::stringstream ss;
-    ss << "[" << nr->id() << "] Reason: new node registered with same name";
-    msg = ss.str();
-    nr->sendShutdown(msg);
+    auto current = internal_->regManager.getNodeByName(nr->id());
+    if (current && current != nr) {
+      ss << "[" << nr->id() << "] Reason: new node registered with same name";
+    } else {
+      ss << "[" << nr->id() << "] Reason: node unreachable";
+    }
+    internal_->shutdownNode(nr, ss.str());
   }
 
   auto graveyard = internal_->regManager.checkNodesForRemoval();

--- a/src/roscore/master.h
+++ b/src/roscore/master.h
@@ -79,6 +79,10 @@ public:
   /// Can return an error if multicast address is invalid.
   Error setDiscoveryGroup(const std::string& group);
 
+  /// Set period for periodic node liveness checks (getPid / local PID probe).
+  /// @param seconds - check interval in seconds; 0 disables periodic checks.
+  void setNodeCheckPeriod(double seconds);
+
   /// Update queued tasks.
   void update();
 

--- a/src/roscore/master_internal.h
+++ b/src/roscore/master_internal.h
@@ -65,6 +65,12 @@ struct Master::Internal {
   /// Some unique UUID of this instance.
   UUID uuid;
 
+  /// Period between node liveness checks (0 disables periodic checks).
+  WallDuration nodeCheckPeriod{5.0};
+
+  /// Timestamp of the last periodic node liveness check.
+  SteadyTime lastNodeCheck;
+
   Internal(const std::shared_ptr<RPCManager>& manager);
   ~Internal();
 
@@ -84,6 +90,13 @@ struct Master::Internal {
   /// Callback for discovery event.
   /// It is called from PollSet thread.
   void onDiscovery(const DiscoveryEvent& evt);
+
+  /// Probe registered nodes via getPid and queue unreachable ones for shutdown.
+  void checkNodesAlive();
+
+  /// Drop registrations for a node, notify remaining subscribers, and optionally
+  /// send a Slave API shutdown request when the connection is still usable.
+  void shutdownNode(const std::shared_ptr<NodeRef>& node, const std::string& reason);
 };
 
 }

--- a/src/roscore/miniroscore.cpp
+++ b/src/roscore/miniroscore.cpp
@@ -95,6 +95,8 @@ int main(int argc, const char ** argv) {
     ("pidfile", po::value<std::string>(), "Path to a PID file")
     ("discovery", po::value<int>(), "Sets UDP port for master discovery.")
     ("discovery_group", po::value<std::string>(), "Multicast address for master discovery")
+    ("node_check_period", po::value<double>()->default_value(5.0),
+      "Period in seconds for checking whether registered nodes are still alive (0 disables)")
     ;
 
   po::variables_map vm;
@@ -169,6 +171,7 @@ int main(int argc, const char ** argv) {
 
   master.setResolveNodeIP(resolve);
   master.setDumpParameters(dumpParameters);
+  master.setNodeCheckPeriod(vm["node_check_period"].as<double>());
 
   PidFile pidFile;
   if (vm.count("pidfile")) {

--- a/src/roscore/node_ref.cpp
+++ b/src/roscore/node_ref.cpp
@@ -238,15 +238,22 @@ std::shared_ptr<http::HttpClient> NodeRef::makeClient(PollSet* ps)
     [wnode, wclient](std::shared_ptr<network::NetSocket> socket, http::HttpClient::State state, Error err)
     {
       if (auto node = wnode.lock()) {
-        node->handleDisconnect(wclient);
+        node->handleDisconnect(wclient, err);
       }
     });
 
   client->setConnectHandler([wnode](std::shared_ptr<network::NetSocket> socket) {
     if (auto node = wnode.lock()) {
       MINIROS_INFO("%s - connected", node->debugName().c_str());
-      std::unique_lock<std::mutex> lock(node->m_guard);
-      node->updateState(State::Connected, lock);
+      std::string callerId;
+      {
+        std::unique_lock<std::mutex> lock(node->m_guard);
+        node->updateState(State::Connected, lock);
+        callerId = node->m_callerId;
+      }
+      // Verify the node after (re)connect; request is queued until the socket is idle.
+      if (!callerId.empty())
+        node->sendGetPid(callerId);
       return true;
     }
     return false;
@@ -280,6 +287,7 @@ Error NodeRef::activateConnection(const std::string& callerId, PollSet* ps)
       return Error::InvalidAddress;
     }
     url = m_apiUrl;
+    m_callerId = callerId;
   }
 
   std::shared_ptr<http::HttpClient> client;
@@ -304,35 +312,64 @@ Error NodeRef::activateConnection(const std::string& callerId, PollSet* ps)
     updateState(State::Connecting, lock);
   }
 
-  sendGetPid(callerId);
+  // getPid is sent from the connect handler once the socket is up.
   return Error::Ok;
 }
 
-void NodeRef::handleDisconnect(const std::weak_ptr<http::HttpClient>& wclient)
+void NodeRef::handleDisconnect(const std::weak_ptr<http::HttpClient>& wclient, Error disconnectError)
 {
   auto client = wclient.lock();
   if (!client) {
     MINIROS_ERROR("%s - http client is lost during disconnect at state=%s", debugName().c_str(), m_state.toString());
     return;
   }
-  std::unique_lock<std::mutex> lock(m_guard);
-  if (m_state == State::ShuttingDown) {
-    deactivateConnectionUnsafe();
-    MINIROS_INFO("%s - disconnected at state=%s, HttpClient state=%s", debugName().c_str(), m_state.toString(), client->getState().toString());
+
+  // Lock order matches activateConnection: m_clientGuard then m_guard.
+  ClientLock clientLock(m_clientGuard);
+  Lock lock(m_guard);
+
+  if (m_state == State::ShuttingDown || m_state == State::Dead) {
+    deactivateConnectionUnsafe(lock, clientLock);
+    MINIROS_INFO("%s - disconnected at state=%s err=%s, HttpClient state=%s",
+                 debugName().c_str(), m_state.toString(), disconnectError.toString(),
+                 client->getState().toString());
     updateState(State::Dead, lock);
+    return;
+  }
+
+  // Connection refused means nothing is listening on the node's Slave API port —
+  // typically the process exited. Do not keep retrying.
+  // Cap other transient failures so we cannot spin reconnect forever.
+  constexpr int kMaxReconnectAttempts = 3;
+  const int attempts = client->getReconnectAttempts();
+  const bool permanentFailure =
+    disconnectError == Error::ConnectionRefused ||
+    disconnectError == Error::InvalidAddress ||
+    attempts >= kMaxReconnectAttempts;
+
+  if (permanentFailure) {
+    MINIROS_WARN("%s - giving up reconnect (err=%s attempts=%d); marking node dead",
+                 debugName().c_str(), disconnectError.toString(), attempts);
+    deactivateConnectionUnsafe(lock, clientLock);
+    updateState(State::Dead, lock);
+    return;
+  }
+
+  if (Error err = client->reconnect(5)) {
+    MINIROS_INFO("%s - disconnected at state %s err=%s. Initiating reconnect (attempt %d)",
+                 debugName().c_str(), m_state.toString(), disconnectError.toString(),
+                 client->getReconnectAttempts());
+    updateState(State::Connecting, lock);
   } else {
-    if (Error err = client->reconnect(5)) {
-      MINIROS_INFO("%s - disconnected at state %s. Initiating reconnect", debugName().c_str(), m_state.toString());
-      updateState(State::Connecting, lock);
-    } else {
-      MINIROS_INFO("%s - disconnected at state %s. Failed to initiate reconnect: %s", debugName().c_str(), m_state.toString(), err.toString());
-      updateState(State::Dead, lock);
-    }
+    MINIROS_INFO("%s - disconnected at state %s. Failed to initiate reconnect: %s",
+                 debugName().c_str(), m_state.toString(), err.toString());
+    deactivateConnectionUnsafe(lock, clientLock);
+    updateState(State::Dead, lock);
   }
 }
 
 
-void NodeRef::deactivateConnectionUnsafe()
+void NodeRef::deactivateConnectionUnsafe(Lock& /*lock*/, ClientLock& /*clientLock*/)
 {
   m_client.reset();
   m_reqGetPid.reset();
@@ -351,7 +388,7 @@ bool NodeRef::needRequests() const
 }
 
 
-void NodeRef::updateState(State newState, Lock& lock)
+void NodeRef::updateState(State newState, Lock& /*lock*/)
 {
   if (newState == m_state)
     return;
@@ -454,27 +491,48 @@ Error NodeRef::sendGetPid(const std::string& callerId)
     return Error::NotConnected;
   }
 
+  std::shared_ptr<http::XmlRpcRequest> reqGetPid;
   {
     std::unique_lock lock(m_guard);
+    if (!callerId.empty())
+      m_callerId = callerId;
+
     if (!m_reqGetPid) {
       m_reqGetPid = http::makeRequest(m_apiUrl.path, "getPid");
-      m_reqGetPid->setParams(callerId);
+      m_reqGetPid->setParams(m_callerId);
       m_reqGetPid->generateRequestBody();
       std::weak_ptr<NodeRef> wnode = this->shared_from_this();
       m_reqGetPid->onComplete = [wnode] (int code, const std::string& msg, const RpcValue& data) {
         if (auto node = wnode.lock())
           node->responseGetPid(code, msg, data);
       };
-    } else if (m_reqShutdown->state() != http::HttpRequest::State::Idle) {
-      // Already sent request.
-      return Error::Ok;
+      m_reqGetPid->setFailureCallback([wnode]() {
+        if (auto node = wnode.lock()) {
+          std::shared_ptr<http::XmlRpcRequest> req;
+          {
+            std::unique_lock lock(node->m_guard);
+            req = node->m_reqGetPid;
+          }
+          if (req)
+            node->m_activeRequests.erase(req);
+        }
+      });
+    } else {
+      auto s = m_reqGetPid->state();
+      if (s != http::HttpRequest::State::Idle && s != http::HttpRequest::State::Done) {
+        // Already in flight.
+        return Error::Ok;
+      }
+      // Reuse completed request object.
+      m_reqGetPid->resetResponse();
+      m_reqGetPid->updateState(http::HttpRequest::State::Idle);
     }
+    reqGetPid = m_reqGetPid;
   }
 
   MINIROS_INFO("%s::sendGetPid()", debugName().c_str());
-  // Generate the request body (no parameters needed for shutdown)
-  m_activeRequests.insert(m_reqShutdown);
-  return client->enqueueRequest(m_reqGetPid);
+  m_activeRequests.insert(reqGetPid);
+  return client->enqueueRequest(reqGetPid);
 }
 
 void NodeRef::responseGetPid(int code, const std::string& msg, const RpcValue& data)
@@ -482,10 +540,12 @@ void NodeRef::responseGetPid(int code, const std::string& msg, const RpcValue& d
   if (code && data.getType() == XmlRpc::XmlRpcValue::TypeInt) {
     std::unique_lock lock(m_guard);
     m_pid = data.as<int>();
-    if (m_state == State::Connecting)
+    MINIROS_INFO("%s::responseGetPid() pid=%d", debugName().c_str(), m_pid);
+    if (m_state == State::Connecting || m_state == State::Connected)
       updateState(State::Verified, lock);
   } else {
-    MINIROS_ERROR("Unexpected response: %s", data.toJsonStr().c_str());
+    MINIROS_ERROR("%s::responseGetPid unexpected response code=%d data=%s msg=%s",
+                  debugName().c_str(), code, data.toJsonStr().c_str(), msg.c_str());
   }
 }
 
@@ -495,6 +555,24 @@ size_t NodeRef::getQueuedRequests() const
   if (!m_client)
     return 0;
   return m_client->getQueuedRequests();
+}
+
+int NodeRef::pid() const
+{
+  std::unique_lock lock(m_guard);
+  return m_pid;
+}
+
+void NodeRef::markDead()
+{
+  // Lock order matches activateConnection: m_clientGuard then m_guard.
+  ClientLock clientLock(m_clientGuard);
+  Lock lock(m_guard);
+  if (m_state == State::Dead)
+    return;
+  MINIROS_WARN("%s::markDead()", debugName().c_str());
+  deactivateConnectionUnsafe(lock, clientLock);
+  updateState(State::Dead, lock);
 }
 
 } // namespace master

--- a/src/roscore/node_ref.h
+++ b/src/roscore/node_ref.h
@@ -177,9 +177,6 @@ public:
   /// @return Error::Ok if connection was initiated successfully, error code otherwise.
   Error activateConnection(const std::string& callerId, PollSet* ps);
 
-  /// Release HTTP client and drop all related objects.
-  void deactivateConnectionUnsafe();
-
   /// Send shutdown request to remote node.
   /// @param msg - message sent to remote node.
   /// @return Error::Ok if request was queued successfully, error code otherwise.
@@ -206,17 +203,30 @@ public:
   /// Get client object.
   std::shared_ptr<http::HttpClient> getClient();
 
+  /// Last known PID of the node process (0 if unknown).
+  /// Obtained via Slave API getPid; not used for OS-level signals.
+  int pid() const;
+
+  /// Mark node as dead and tear down its HTTP client.
+  void markDead();
+
 protected:
   using Lock = std::unique_lock<std::mutex>;
-  void updateState(State newState, Lock& lock);
+  using ClientLock = std::unique_lock<std::mutex>;
+
+  void updateState(State newState, Lock& lock) REQUIRES(m_guard);
+
+  /// Release HTTP client and drop all related objects.
+  /// @param lock - must already own m_guard.
+  /// @param clientLock - must already own m_clientGuard.
+  void deactivateConnectionUnsafe(Lock& lock, ClientLock& clientLock) REQUIRES(m_guard) REQUIRES(m_clientGuard);
 
   /// Creates client object.
   std::shared_ptr<http::HttpClient> makeClient(PollSet* ps);
 
   /// Handler for disconnect events from HttpClient.
-  void handleDisconnect(const std::weak_ptr<http::HttpClient>& client);
+  void handleDisconnect(const std::weak_ptr<http::HttpClient>& client, Error disconnectError);
 
-protected:
   std::set<std::string> m_paramSubscriptions;
   std::set<std::string> m_topicSubscriptions;
   std::set<std::string> m_topicPublications;
@@ -237,6 +247,9 @@ protected:
   int m_pid = 0;
 
   int m_flags = 0;
+
+  /// Caller id used for Slave API requests (typically master name).
+  std::string m_callerId;
 
   /// Generic guard for data and state objects.
   mutable std::mutex m_guard;

--- a/src/roscore/registration_manager.cpp
+++ b/src/roscore/registration_manager.cpp
@@ -237,6 +237,25 @@ std::set<std::shared_ptr<NodeRef>> RegistrationManager::pullShutdownNodes()
   return result;
 }
 
+void RegistrationManager::scheduleShutdown(const std::shared_ptr<NodeRef>& node)
+{
+  assert(node);
+  if (!node)
+    return;
+  std::scoped_lock<std::mutex> lock(m_guard);
+  m_nodesToShutdown.insert(node);
+}
+
+void RegistrationManager::scheduleDeadNodesForShutdown()
+{
+  std::scoped_lock<std::mutex> lock(m_guard);
+  for (const auto& [key, node] : m_nodes) {
+    assert(node);
+    if (node->getState() == NodeRef::State::Dead)
+      m_nodesToShutdown.insert(node);
+  }
+}
+
 std::vector<NodeRefPtr> RegistrationManager::checkNodesForRemoval()
 {
   std::vector<NodeRefPtr> graveyard;

--- a/src/roscore/registration_manager.h
+++ b/src/roscore/registration_manager.h
@@ -102,6 +102,13 @@ public:
   /// Take collection of nodes for shutdown.
   std::set<std::shared_ptr<NodeRef>> pullShutdownNodes();
 
+  /// Queue a node for shutdown / unregistration on the next Master::update().
+  /// Used for superseded nodes and for nodes that became unreachable.
+  void scheduleShutdown(const std::shared_ptr<NodeRef>& node);
+
+  /// Queue all currently Dead nodes that are still registered.
+  void scheduleDeadNodesForShutdown();
+
   std::ostream& writeJson(std::ostream& os, miniros::JsonState& state, const miniros::JsonSettings& settings) const;
 
   /// Drop all registrations for specified node.


### PR DESCRIPTION
roscore now will try to check whether nodes are alive by sending getPID requests to them. Nodes, which fail to respond will be considered dead and be removed from registrations.