### PR TITLE
Minor improvement for compatibility with Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 include/generated/*/*.h
+
+# Android NDK out-of-tree builds
+build-android/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,21 @@ option(MINIROS_SANITIZE_THREADS "Use TSan to find potential data races" OFF)
 option(MINIROS_THREAD_SAFETY_ANALYSIS  "Use static thread checking from clang" OFF)
 option(MINIROS_PORTABLE_TOOLS "Make miniroscore and minibag portable. Forces linking to static library" OFF)
 
+# NDK / Android toolchain builds (CMAKE_TOOLCHAIN_FILE=android.toolchain.cmake).
+# Requires NDK r22+: libc++ ships std::filesystem there; miniros uses it in the core library.
+# See docs/android.md.
+if(ANDROID)
+  message(STATUS "Android NDK build: static roscxx for console tools (ADB-friendly)")
+  set(MINIROS_BUILD_SHARED OFF CACHE BOOL "Build shared version of miniros" FORCE)
+  set(MINIROS_PORTABLE_TOOLS ON CACHE BOOL "Portable tools" FORCE)
+  set(MINIROS_PATCH_RPATH OFF CACHE BOOL "Update RPATH to use install paths" FORCE)
+  set(MINIROS_USE_SYSTEM_BZIP2 OFF CACHE BOOL "Use bzip2 from system" FORCE)
+  set(MINIROS_USE_SYSTEM_LZ4 OFF CACHE BOOL "Use lz4 from system" FORCE)
+  set(MINIROS_USE_SYSTEM_PROGRAM_OPTIONS OFF CACHE BOOL "Use boost::program_options" FORCE)
+  set(MINIROS_ROSBAG_USE_GPGME_ENCRYPTION OFF CACHE BOOL "Use GPGME encryption support" FORCE)
+  set(MINIROS_ROSBAG_USE_OPENSSL_ENCRYPTION OFF CACHE BOOL "Use openssl encryption for rosbag" FORCE)
+endif()
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
   option(MINIROS_USE_LIBSYSTEMD "Signal systemd when node has actually started" ON)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,13 +10,20 @@ set_target_properties (bag_write PROPERTIES FOLDER "Examples")
 
 # Example publisher and subscriber
 # It follows official ROS tutorial at http://wiki.ros.org/ROS/Tutorials/WritingPublisherSubscriber%28c%2B%2B%29
+# On Android, link the static archive so ADB pushes self-contained binaries.
+if (ANDROID)
+  set(MINIROS_EXAMPLE_ROSCXX roscxx_static)
+else()
+  set(MINIROS_EXAMPLE_ROSCXX roscxx)
+endif()
+
 add_executable(talker talker.cpp)
-target_link_libraries(talker roscxx)
+target_link_libraries(talker ${MINIROS_EXAMPLE_ROSCXX})
 target_include_directories(talker PRIVATE ${MINIROS_INCLUDE_GENERATED_DIRS})
 set_target_properties (talker PROPERTIES FOLDER "Examples")
 
 add_executable(listener listener.cpp)
-target_link_libraries(listener roscxx)
+target_link_libraries(listener ${MINIROS_EXAMPLE_ROSCXX})
 target_include_directories(listener PRIVATE ${MINIROS_INCLUDE_GENERATED_DIRS})
 set_target_properties (listener PROPERTIES FOLDER "Examples")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -304,8 +304,10 @@ if (MINIROS_BUILD_SHARED)
   )
 
   add_library(roscxx_static STATIC ${ALL_SRC})
+  target_compile_options(roscxx_static PRIVATE ${MINIROS_COMPILE_OPTIONS})
   target_link_options(roscxx_static PRIVATE ${MINIROS_LINK_OPTIONS})
   set_property(TARGET roscxx_static PROPERTY CXX_STANDARD 17)
+  set_property(TARGET roscxx_static PROPERTY POSITION_INDEPENDENT_CODE ON)
 
   target_include_directories(roscxx_static
       PRIVATE
@@ -339,23 +341,35 @@ set_property(TARGET roscxx PROPERTY CXX_STANDARD 17)
 
 if(WIN32)
   set(PLATFORM_LIBS wsock32 ws2_32)
+elseif(ANDROID)
+  # NDK uses libc++; std::filesystem is in the C++ runtime (no libstdc++fs).
+  set(PLATFORM_LIBS)
 else()
   set(PLATFORM_LIBS stdc++fs)
 endif()
 
-target_link_libraries(roscxx PRIVATE
-    ${console_bridge_LIBRARIES} 
-    ${PKG_LIBS_LIBRARIES} 
-    ${PLATFORM_LIBS} 
-    Threads::Threads
+target_link_libraries(roscxx
+    PUBLIC Threads::Threads
+    PRIVATE
+    ${console_bridge_LIBRARIES}
+    ${PKG_LIBS_LIBRARIES}
+    ${PLATFORM_LIBS}
 )
+
+# Propagate link deps to executables that use the static archive (portable tools / Android).
+if (MINIROS_BUILD_SHARED)
+  target_link_libraries(roscxx_static
+      PUBLIC Threads::Threads
+      PRIVATE ${console_bridge_LIBRARIES} ${PKG_LIBS_LIBRARIES} ${PLATFORM_LIBS})
+endif()
 
 find_package(PkgConfig QUIET)
 
 add_executable(miniroscore roscore/miniroscore.cpp)
 
 set(MINIROSCORE_LIBS impl::program_options)
-if (MINIROS_PORTABLE_TOOLS)
+# Android and MINIROS_PORTABLE_TOOLS: single-file binaries (no libroscxx.so).
+if (ANDROID OR MINIROS_PORTABLE_TOOLS)
   list(APPEND MINIROSCORE_LIBS roscxx_static)
 else()
   list(APPEND MINIROSCORE_LIBS roscxx)
@@ -403,7 +417,7 @@ add_executable(minibag
 
 set(MINIBAG_LIBS bag_storage impl::program_options Threads::Threads)
 
-if (MINIROS_PORTABLE_TOOLS)
+if (ANDROID OR MINIROS_PORTABLE_TOOLS)
   list(APPEND MINIBAG_LIBS roscxx_static)
 else()
   list(APPEND MINIBAG_LIBS roscxx)


### PR DESCRIPTION
Updated CMakeLists to better address specifics of android build:
1. Static library is preferred
2. Updated apps to use static libroscxx.