### PR TITLE
Restore state

### DIFF
--- a/.github/workflows/cmake-multiplatform.yml
+++ b/.github/workflows/cmake-multiplatform.yml
@@ -113,7 +113,10 @@ jobs:
       run: |
         ctest --output-on-failure --test-dir test -V --timeout ${{ steps.strings.outputs.test-timeout }} -E advanced -C ${{ matrix.build_type }}
 
+    # Still run when Test-basic fails: advanced is where shared miniroscore
+    # death shows up, and we need master-logs/crash dumps in the artifact.
     - name: Test-advanced
+      if: ${{ success() || failure() }}
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       env:
         ROS_MASTER_URI: "http://localhost:11311"
@@ -122,17 +125,68 @@ jobs:
         HANG_TIMEOUT: ${{ steps.strings.outputs.hang-timeout }}
         TSAN_OPTIONS: "halt_on_error=1:second_deadlock_stack=1:history_size=7"
         # Shared miniroscore for advanced suite. Tests call requireMasterOrExit() after init
-        # (exit 90 → launch_test.sh dumps master stacks + rosout).
+        # (exit 90 → launch_test.sh dumps master stacks + rosout/crash/cores).
+        # Console + crash dumps always go under MINIROS_MASTER_LOG_DIR (uploaded on failure).
         MINIROS_MASTER_DEBUG: ${{ env.MINIROS_MASTER_DEBUG }}
         MINIROS_MASTER_LOG_DIR: ${{ steps.strings.outputs.build-output-dir }}/master-logs
         ROS_LOG_DIR: ${{ steps.strings.outputs.build-output-dir }}/master-logs
       run: |
         mkdir -p "$MINIROS_MASTER_LOG_DIR"
+        # Core pattern is relative to the process cwd (bin/); keep a copy path under build too.
+        mkdir -p cores "${{ github.workspace }}/cores"
         ./bin/manage-master start
         ctest --output-on-failure --test-dir test -V --timeout ${{ steps.strings.outputs.test-timeout }} -R advanced -C ${{ matrix.build_type }}
         ls -alh .
         ls -alh "$MINIROS_MASTER_LOG_DIR" || true
+        ls -alh cores "${{ github.workspace }}/cores" 2>/dev/null || true
         ./bin/manage-master stop
+
+    # Echo crash stacks into the job log so investigation does not require the zip.
+    - name: Dump-master-crash-logs
+      if: ${{ failure() }}
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      run: |
+        set +e
+        echo "======== MASTER CRASH / CONSOLE (job log excerpt) ========"
+        for f in \
+          bin/late-master-logs/miniroscore.crash \
+          bin/late-master-logs/miniroscore.console.log \
+          master-logs/miniroscore.crash \
+          master-logs/miniroscore.console.log \
+          master-logs/master-fail-*/miniroscore.crash \
+          master-logs/master-fail-*/miniroscore.console.log \
+          master-logs/master-fail-*/*.bt.txt
+        do
+          for path in $f; do
+            [ -f "$path" ] || continue
+            sz=$(wc -c <"$path" | tr -d ' ')
+            echo "----- $path ($sz bytes) -----"
+            if [ "$sz" = "0" ]; then
+              echo "(empty)"
+              continue
+            fi
+            case "$path" in
+              *.crash|*.bt.txt)
+                cat "$path"
+                ;;
+              *)
+                if command -v rg >/dev/null 2>&1; then
+                  if rg -n "fatalSignalHandler|ThreadSanitizer|AddressSanitizer|SUMMARY:|DEADLYSIGNAL|ABORTING|SIGSEGV|signal=" "$path"; then
+                    :
+                  else
+                    echo "(no sanitizer/crash markers; last 120 lines)"
+                    tail -n 120 "$path"
+                  fi
+                else
+                  grep -nE 'fatalSignalHandler|ThreadSanitizer|AddressSanitizer|SUMMARY:|DEADLYSIGNAL|ABORTING|SIGSEGV|signal=' "$path" \
+                    || { echo "(no sanitizer/crash markers; last 120 lines)"; tail -n 120 "$path"; }
+                fi
+                ;;
+            esac
+          done
+        done
+        echo "======== END MASTER CRASH / CONSOLE ========"
+        ls -la bin/late-master-logs master-logs cores bin/cores 2>/dev/null || true
 
     - name: Test-memcheck
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
@@ -153,5 +207,10 @@ jobs:
           name: cores-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.c_compiler }}
           path: |
             cores/
+            ${{ github.workspace }}/cores/
+            ${{ steps.strings.outputs.build-output-dir }}/cores/
+            ${{ steps.strings.outputs.build-output-dir }}/bin/cores/
             ${{ steps.strings.outputs.build-output-dir }}/master-logs/
+            ${{ steps.strings.outputs.build-output-dir }}/bin/late-master-logs/
+            ${{ steps.strings.outputs.build-output-dir }}/bin/master-fail-*/
           if-no-files-found: ignore

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -14,13 +14,15 @@ Here is the list of different envorinment variables, which can influence behavio
 
 **HOME** - the last choice for picking ROS log folder.
 
-**MINIROS_MASTER_LOG_DIR** - preferred log directory for CI/`manage-master` (also exported as `ROS_LOG_DIR` to miniroscore). Contains `rosout.log` from the master's Rosout aggregator.
+**MINIROS_MASTER_LOG_DIR** - preferred log directory for CI/`manage-master` (also exported as `ROS_LOG_DIR` to miniroscore). Contains `rosout.log` from the master's Rosout aggregator, plus `miniroscore.console.log` and `miniroscore.crash`.
 
-**MINIROS_MASTER_DEBUG** - if `1`/`true`, `manage-master start` raises `--xmlrpc_log=4` and redirects miniroscore stdout/stderr to `$MINIROS_MASTER_LOG_DIR/miniroscore.console.log` (detached masters normally discard stdio).
+**MINIROS_MASTER_DEBUG** - if `1`/`true`, `manage-master start` raises `--xmlrpc_log=4`.
 
-**MINIROS_MASTER_CONSOLE_LOG** - internal path used by `Launcher` when `MINIROS_MASTER_DEBUG` is on; usually set by `manage-master`.
+**MINIROS_MASTER_CONSOLE_LOG** - path for redirected miniroscore stdout/stderr; set by `manage-master` whenever a log dir is used (detached masters normally discard stdio).
 
-Tests that need a live master should call `miniros::test::requireMasterOrExit()` from `test/require_master.h` right after `miniros::init()` (exits **90** on failure). `MasterLink::check()` uses XML-RPC `getPid`. Creating a `NodeHandle` afterwards also registers `/rosout`, which is easy to spot in miniroscore logs. `launch_test.sh` dumps master stacks + rosout when a test exits 90.
+**MINIROS_CRASH_LOG** - file where `handleCrashes()` writes an async-signal-safe stack dump on SIGSEGV/SIGABRT/…; `manage-master` points this at `$MINIROS_MASTER_LOG_DIR/miniroscore.crash`.
+
+Tests that need a live master should call `miniros::test::requireMasterOrExit()` from `test/require_master.h` right after `miniros::init()` (exits **90** on failure). `MasterLink::check()` uses XML-RPC `getPid`. Creating a `NodeHandle` afterwards also registers `/rosout`, which is easy to spot in miniroscore logs. `launch_test.sh` dumps master stacks + rosout/crash/core artifacts when a test exits 90 or the shared master dies mid-run, and prints crash/console excerpts to stderr so they appear in the CI job log. On CI failure, the `Dump-master-crash-logs` workflow step also echoes `bin/late-master-logs/` and `master-logs/` crash/console into the job log (artifact zip still uploaded).
 
 **ROSCONSOLE_FORMAT** - specifies format for logging messages. More details can be found at [logging.md](logging.md)
 

--- a/docs/rosmaster.md
+++ b/docs/rosmaster.md
@@ -36,9 +36,31 @@ Liveness and cleanup:
 2. **Periodic probe** — `Master::update()` periodically re-sends `getPid` to verify the Slave API is reachable.
 3. **Shutdown queue** — Dead / superseded nodes are placed into `RegistrationManager::m_nodesToShutdown`.
    Processing that queue drops registrations and notifies remaining nodes about updated publications.
+4. **Cache restore** — nodes loaded from disk start in `Restoring`, move to `Recovering` after `getPid`,
+   then to `Verified` once `getPublications` / `getSubscriptions` complete.
 
 The check period is configured with the `--node_check_period` option of `miniroscore` (seconds; `0` disables
 periodic checks). Default is 5 seconds.
+
+# Persistent state #
+
+`miniroscore` can persist a per-port cache file so a restarted master keeps the same instance GUID
+(`/run_id`) and can reattach to nodes that survived the master's downtime.
+
+State is stored as `cache.<port>` in the current working directory (for example
+`/var/run/miniroscore/cache.11311` when started with `--dir=/var/run/miniroscore`).
+Pass `--no-cache` to disable persistence.
+
+On startup the master:
+
+1. Loads `cache.<port>` once (GUID, nodes, and last-known node states).
+2. Reuses that GUID for `/run_id`, or generates a new one on first run.
+3. Re-registers each cached node by name + Slave API URI (skipping dead cached states / PIDs).
+4. After `getPid` verifies the node, requests `getPublications` / `getSubscriptions` and re-registers them.
+5. Restores services from the cache snapshot (ROS Slave API has no `getServices`).
+6. Sends `publisherUpdate` as topics are restored.
+
+The cache is rewritten when the graph changes and again on clean shutdown.
 
 # Process readiness #
 

--- a/include/miniros/common.h
+++ b/include/miniros/common.h
@@ -91,7 +91,11 @@ struct MINIROS_DECL UUID {
   /// Check if UUID is valid.
   bool valid() const;
 
+  /// Canonical string form: 8-4-4-4-12 lowercase hex.
   std::string toString() const;
+
+  /// Parse canonical UUID string (dashes optional). Returns false on failure.
+  bool fromString(const std::string& str);
 };
 
 MINIROS_DECL bool operator == (const UUID& a, const UUID& b);
@@ -99,6 +103,10 @@ MINIROS_DECL bool operator == (const UUID& a, const UUID& b);
 MINIROS_DECL Error makeDirectory(const std::string& path);
 
 MINIROS_DECL Error changeCurrentDirectory(const std::string& path);
+
+/// Best-effort check whether a process with the given PID is still alive.
+/// @param pid - OS process id; values <= 0 are treated as unknown and return true.
+MINIROS_DECL bool isProcessAlive(int pid);
 
 /// Enable printing backtrace during crash.
 /// For internal usage only.

--- a/include/miniros/common.h
+++ b/include/miniros/common.h
@@ -108,8 +108,9 @@ MINIROS_DECL Error changeCurrentDirectory(const std::string& path);
 /// @param pid - OS process id; values <= 0 are treated as unknown and return true.
 MINIROS_DECL bool isProcessAlive(int pid);
 
-/// Enable printing backtrace during crash.
-/// For internal usage only.
+/// Enable printing backtrace during crash (stderr + optional crash log file).
+/// Opens `$MINIROS_CRASH_LOG`, or `$MINIROS_MASTER_LOG_DIR/miniroscore.crash`,
+/// or `./miniroscore.crash`. For internal / CI usage.
 MINIROS_DECL Error handleCrashes();
 
 

--- a/include/miniros/http/xmlrpc_request.h
+++ b/include/miniros/http/xmlrpc_request.h
@@ -94,7 +94,7 @@ private:
 /// Initializes XMLRPC request to specified URL.
 /// @param path - path/endpoint part of URL.
 /// @param method - name of XMLRPC method.
-std::shared_ptr<XmlRpcRequest> makeRequest(const std::string& path, const std::string& method);
+MINIROS_DECL std::shared_ptr<XmlRpcRequest> makeRequest(const std::string& path, const std::string& method);
 
 } // namespace http
 } // namespace miniros

--- a/include/miniros/launcher.h
+++ b/include/miniros/launcher.h
@@ -43,6 +43,11 @@ public:
   /// Create launcher for specific PID.
   explicit Launcher(int64_t pid);
 
+  Launcher(const Launcher&) = delete;
+  Launcher& operator=(const Launcher&) = delete;
+  Launcher(Launcher&&) = delete;
+  Launcher& operator=(Launcher&&) = delete;
+
   ~Launcher();
 
   enum Flags {

--- a/include/miniros/platform.h
+++ b/include/miniros/platform.h
@@ -61,6 +61,44 @@ inline bool get_environment_variable(std::string &str, const char* environment_v
 	}
 }
 
+/**
+ * Cross-platform setenv: set (or optionally leave) an environment variable.
+ * @return true on success.
+ */
+inline bool set_environment_variable(const char* name, const char* value, bool overwrite = true) {
+	if (!name || !value) {
+		return false;
+	}
+#ifdef _WIN32
+	if (!overwrite) {
+		size_t envsize = 0;
+		const errno_t errcode = getenv_s(&envsize, NULL, 0, name);
+		if (errcode || envsize) {
+			return errcode == 0;
+		}
+	}
+	return _putenv_s(name, value) == 0;
+#else
+	return setenv(name, value, overwrite ? 1 : 0) == 0;
+#endif
+}
+
+/**
+ * Cross-platform unsetenv: remove an environment variable.
+ * @return true on success (including when the variable was already unset).
+ */
+inline bool unset_environment_variable(const char* name) {
+	if (!name) {
+		return false;
+	}
+#ifdef _WIN32
+	// Empty value removes the variable with the CRT putenv helpers.
+	return _putenv_s(name, "") == 0;
+#else
+	return unsetenv(name) == 0;
+#endif
+}
+
 } // namespace miniros
 
 #endif // MINIROS_PLATFORM_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -266,6 +266,7 @@ set(transport_SRC
 set(master_SRC
     roscore/discovery.cpp
     roscore/master.cpp
+    roscore/master_cache.cpp
     roscore/master_endpoints.cpp
     roscore/master_handler.cpp
     roscore/master_html_printers.cpp

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -474,46 +474,90 @@ bool isProcessAlive(int pid)
 #ifdef HAVE_GLIBC_BACKTRACE
 static constexpr size_t MAX_STACKTRACE_DEPTH = 64;
 
+/// Pre-opened crash dump fd (async-signal-safe target). -1 = none.
+static int g_crashLogFd = -1;
+
 static void writeStackTrace(int file_descriptor) {
   void* trace[MAX_STACKTRACE_DEPTH];
   size_t trace_depth = backtrace(trace, MAX_STACKTRACE_DEPTH);
   // Note that we skip the first frame here so this function won't show up in
   // the printed trace.
-  backtrace_symbols_fd(trace + 1, trace_depth - 1, file_descriptor);
+  backtrace_symbols_fd(trace + 1, static_cast<int>(trace_depth) - 1, file_descriptor);
 }
 
-/******************************************************************************/
+static void writeAll(int fd, const char* msg, size_t len)
+{
+  if (fd < 0 || !msg || len == 0)
+    return;
+  // Best-effort; ignore short writes in a signal handler.
+  (void)::write(fd, msg, len);
+}
+
 static void fatalSignalHandler(int signal) {
   // Restore the default signal handler for SIGSEGV in case another one
   // happens, and for the re-issue below.
   std::signal(signal, SIG_DFL);
 
-  // WriteStackTrace should theoretically be safe to call here.
-  static constexpr const char error_msg[] =
-      "*** fatalSignalHandler stack trace: ***\n";
-  // Write using safe `write` function. Skip null character.
-  if (write(fileno(stderr), error_msg, sizeof(error_msg) - 1) > 0) {
-    writeStackTrace(fileno(stderr));
+  char header[128];
+  // snprintf is not strictly async-signal-safe but widely used in crash handlers;
+  // keep it short and stack-local.
+  const int headerLen = std::snprintf(header, sizeof(header),
+    "*** fatalSignalHandler signal=%d pid=%d stack trace: ***\n", signal, static_cast<int>(::getpid()));
+
+  auto emit = [&](int fd) {
+    if (fd < 0)
+      return;
+    if (headerLen > 0)
+      writeAll(fd, header, static_cast<size_t>(headerLen));
+    writeStackTrace(fd);
+    ::fsync(fd);
+  };
+
+  emit(fileno(stderr));
+  if (g_crashLogFd >= 0 && g_crashLogFd != fileno(stderr))
+    emit(g_crashLogFd);
+
+  // Give I/O a moment, then re-raise so the default handler can dump core / exit.
+  sleep(1);
+  ::raise(signal);
+}
+
+static int openCrashLogFd()
+{
+  // Prefer an explicit path, then log dirs used by CI / manage-master.
+  const char* path = std::getenv("MINIROS_CRASH_LOG");
+  char buf[512];
+  if (!path || !*path) {
+    const char* dir = std::getenv("MINIROS_MASTER_LOG_DIR");
+    if (!dir || !*dir)
+      dir = std::getenv("ROS_LOG_DIR");
+    if (dir && *dir) {
+      std::snprintf(buf, sizeof(buf), "%s/miniroscore.crash", dir);
+      path = buf;
+    } else {
+      path = "miniroscore.crash";
+    }
   }
 
-  // Give dummy function time to run. Use "safe" sleep() function.
-  sleep(1);
-
-  // Now that the signal handler has been removed we can simply return. If
-  // SIGSEGV/SIGABRT was triggered by an instruction, it will occur again. This
-  // time it will be handled by the default handler which triggers a core dump.
-  return;
+  // O_APPEND so concurrent threads don't clobber each other; truncate on open.
+  const int fd = ::open(path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
+  if (fd < 0)
+    return -1;
+  return fd;
 }
 #endif
 
 Error handleCrashes()
 {
 #ifdef HAVE_GLIBC_BACKTRACE
-  // Use our function to handle segmentation faults.
-  // Could add additional signals like: SIGSEGV, SIGSYS, etc.
+  if (g_crashLogFd < 0)
+    g_crashLogFd = openCrashLogFd();
+
   std::signal(SIGSEGV, fatalSignalHandler);
   std::signal(SIGABRT, fatalSignalHandler);
   std::signal(SIGILL, fatalSignalHandler);
+  std::signal(SIGFPE, fatalSignalHandler);
+  std::signal(SIGBUS, fatalSignalHandler);
 #else
   return Error::NotSupported;
 #endif

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -34,6 +34,7 @@
 
 #include "miniros/common.h"
 
+#include <cstring>
 #include <random>
 #include <sstream>
 #include <cstdlib>
@@ -332,7 +333,7 @@ Error notifyNodeExiting(const NodeNotifyInfo& info)
 
 static std::random_device              rd;
 static std::mt19937                    gen(rd());
-static std::uniform_int_distribution<> dis(0, 15);
+static std::uniform_int_distribution<> dis(0, 255);
 
 constexpr unsigned int UUID_Version = 0x40;
 constexpr unsigned int UUID_Variant = 0x80;
@@ -373,26 +374,53 @@ bool UUID::valid() const
   return false;
 }
 
-/// Most lazy method to return string form of UUID.
 std::string UUID::toString() const
 {
-  std::stringstream ss;
-  ss << std::hex;
-  int i = 0;
-  for (;i < 4; i++)
-    ss << static_cast<int>(bytes[i]);
-  ss << "-";
-  for (; i < 6; i++)
-    ss << static_cast<int>(bytes[i]);
-  ss << "-";
-  for (; i < 8; i++)
-    ss << static_cast<int>(bytes[i]);
-  for (; i < 12; i++)
-    ss << static_cast<int>(bytes[i]);
-  ss << "-";
-  for (; i < 16; i++)
-    ss << static_cast<int>(bytes[i]);
-  return ss.str();
+  static const char* hex = "0123456789abcdef";
+  std::string out;
+  out.reserve(36);
+  for (int i = 0; i < Dim; ++i) {
+    if (i == 4 || i == 6 || i == 8 || i == 10)
+      out.push_back('-');
+    out.push_back(hex[bytes[i] >> 4]);
+    out.push_back(hex[bytes[i] & 0xf]);
+  }
+  return out;
+}
+
+bool UUID::fromString(const std::string& str)
+{
+  auto hexNibble = [](char c) -> int {
+    if (c >= '0' && c <= '9')
+      return c - '0';
+    if (c >= 'a' && c <= 'f')
+      return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F')
+      return c - 'A' + 10;
+    return -1;
+  };
+
+  uint8_t parsed[Dim] = {};
+  size_t byteIndex = 0;
+  for (size_t i = 0; i < str.size() && byteIndex < Dim; ) {
+    if (str[i] == '-') {
+      ++i;
+      continue;
+    }
+    if (i + 1 >= str.size())
+      return false;
+    const int hi = hexNibble(str[i]);
+    const int lo = hexNibble(str[i + 1]);
+    if (hi < 0 || lo < 0)
+      return false;
+    parsed[byteIndex++] = static_cast<uint8_t>((hi << 4) | lo);
+    i += 2;
+  }
+  if (byteIndex != Dim)
+    return false;
+
+  std::memcpy(bytes, parsed, Dim);
+  return valid();
 }
 
 bool operator == (const UUID& a, const UUID& b)
@@ -421,6 +449,26 @@ Error changeCurrentDirectory(const std::string& path)
   }
   std::filesystem::current_path(path);
   return Error::Ok;
+}
+
+bool isProcessAlive(int pid)
+{
+  if (pid <= 0)
+    return true;
+
+#if defined(WIN32) || defined(_WIN32)
+  HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, static_cast<DWORD>(pid));
+  if (!h)
+    return false;
+  DWORD exitCode = 0;
+  const BOOL ok = GetExitCodeProcess(h, &exitCode);
+  CloseHandle(h);
+  return ok && exitCode == STILL_ACTIVE;
+#else
+  if (::kill(pid, 0) == 0)
+    return true;
+  return errno == EPERM;
+#endif
 }
 
 #ifdef HAVE_GLIBC_BACKTRACE

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -271,13 +271,13 @@ void HttpClient::Internal::release(Lock& lock) REQUIRES(process_guard)
   {
     ScopedUnlock unlock(lock);
     if (activeReq) {
-      activeReq->updateState(http::HttpRequest::State::Idle);
       activeReq->notifyFailToSend();
+      activeReq->updateState(http::HttpRequest::State::Idle);
       activeReq.reset();
     }
     for (const auto& req: requestsCopy) {
-      req->updateState(http::HttpRequest::State::Idle);
       req->notifyFailToSend();
+      req->updateState(http::HttpRequest::State::Idle);
     }
   }
 }
@@ -403,7 +403,6 @@ void HttpClient::Internal::handleDisconnect(Lock& lock, Error disconnectError)
         req->updateState(HttpRequest::State::ClientQueued);
         keepRetrying.push_back(std::move(req));
       } else {
-        req->updateState(HttpRequest::State::Idle);
         failedRequests.push_back(std::move(req));
       }
     };
@@ -435,6 +434,7 @@ void HttpClient::Internal::handleDisconnect(Lock& lock, Error disconnectError)
     ScopedUnlock unlock(lock);
     for (auto& req : failedRequests) {
       req->notifyFailToSend();
+      req->updateState(HttpRequest::State::Idle);
     }
 
     if (onDisconnectCopy && alive) {

--- a/src/http/http_client.cpp
+++ b/src/http/http_client.cpp
@@ -385,26 +385,38 @@ void HttpClient::Internal::handleDisconnect(Lock& lock, Error disconnectError)
 
   // TODO: change state only if callback has not changed state anyhow.
   updateState(lock, State::Disconnected);
+  // Drop partial HTTP/XML parse state so a reconnect cannot finish a stale frame.
+  resetIntermediateBuffers();
 
-  std::deque<std::shared_ptr<HttpRequest>> requestsCopy;
+  // Non-retryable requests are failed and removed. Retryable ones stay queued
+  // (ClientQueued) for reconnect — do not call notifyFailToSend on those.
+  std::deque<std::shared_ptr<HttpRequest>> failedRequests;
 
-  // Copy of previous active request.
-  std::shared_ptr<HttpRequest> active_copy;
-
-  // Push active request back to queue.
   {
     std::scoped_lock reqLock(requests_guard);
-    if (active_request) {
-      std::swap(active_copy, active_request);
-      if (active_copy->shouldRetry()) {
-        requests.push_front(active_copy);
-        active_copy->updateState(HttpRequest::State::ClientQueued);
-        active_copy.reset();
+    std::deque<std::shared_ptr<HttpRequest>> keepRetrying;
+
+    auto classify = [&](std::shared_ptr<HttpRequest> req) {
+      if (!req)
+        return;
+      if (req->shouldRetry()) {
+        req->updateState(HttpRequest::State::ClientQueued);
+        keepRetrying.push_back(std::move(req));
       } else {
-        active_copy->updateState(HttpRequest::State::Idle);
+        req->updateState(HttpRequest::State::Idle);
+        failedRequests.push_back(std::move(req));
       }
+    };
+
+    if (active_request) {
+      classify(std::move(active_request));
+      active_request.reset();
     }
-    requestsCopy = requests;
+    while (!requests.empty()) {
+      classify(std::move(requests.front()));
+      requests.pop_front();
+    }
+    requests = std::move(keepRetrying);
   }
 
   // Copying all mutable data, which can be changed during callback.
@@ -415,18 +427,13 @@ void HttpClient::Internal::handleDisconnect(Lock& lock, Error disconnectError)
   }
   auto socketCopy = socket;
 
-  const bool hasAnyCallbacks = !requestsCopy.empty() || active_copy || (onDisconnectCopy && alive);
+  const bool hasAnyCallbacks = !failedRequests.empty() || (onDisconnectCopy && alive);
 
   // All the following callbacks must be called without holding either requests_guard or process_guard.
   // Keeping any of these mutexes locked will lead to potential deadlock caused by calling HttpClient methods in callback.
   if (hasAnyCallbacks) {
     ScopedUnlock unlock(lock);
-    if (active_copy) {
-      active_copy->notifyFailToSend();
-    }
-
-    // TODO: Do we need to drop them?
-    for (auto req: requestsCopy) {
+    for (auto& req : failedRequests) {
       req->notifyFailToSend();
     }
 
@@ -558,19 +565,26 @@ Error HttpClient::Internal::readResponse()
         LOCAL_DEBUG("HttpClient[%s]::readResponse: EOF while reading request", debugName().c_str());
         response_http_frame.finishResponse();
         return Error::EndOfFile;
-        // Either way we close the connection
       }
       LOCAL_DEBUG("HttpClient[%s]::readResponse got only %d/%d bytes.", debugName().c_str(), response_http_frame.bodyLength(), response_http_frame.contentLength());
       return Error::WouldBlock;
     }
 
     assert(response_http_frame.state() == HttpParserFrame::ParseComplete);
-    // Otherwise, parse and dispatch the request
     LOCAL_DEBUG("HttpClient[%s]::readResponse read %d/%d bytes.", debugName().c_str(), response_http_frame.bodyLength(), response_http_frame.contentLength());
-  } else if (readErr == Error::WouldBlock) {
+    return Error::Ok;
+  }
+
+  if (readErr == Error::WouldBlock) {
     return Error::WouldBlock;
   }
-  return Error::Ok;
+
+  // Peer closed (n==0 → EndOfFile) or hard error with no new bytes. Never treat
+  // that as a successful empty HTTP response — that used to run XmlRpc parse on
+  // an empty body ("no methodResponse") for every in-flight request.
+  if (readErr != Error::Ok)
+    return readErr;
+  return Error::EndOfFile;
 }
 
 HttpClient::HttpClient(PollSet* ps)
@@ -936,8 +950,10 @@ void HttpClient::handleSocketEvents(const std::shared_ptr<Internal>& I, int evtF
         // Can we actually be here?
         I->handleDisconnect(lock, Error::SystemError);
       } else if (evtFlags & PollSet::EventIn) {
-        // Not expecting to read anything. But we can get this event to call 'read' and receive 0 bytes.
-        // This is disconnect event.
+        // Idle clients do not expect inbound data; EventIn with a readable EOF
+        // means the peer closed. Drain via handleDisconnect (readResponse would
+        // also see EndOfFile once we leave Idle with a request in flight).
+        I->handleDisconnect(lock, Error::EndOfFile);
       } else if (evtFlags & PollSet::EventTimer) {
         // Got timeout waiting - call idle timeout handler
         TimeoutHandler callback;

--- a/src/http/http_server_connection.cpp
+++ b/src/http/http_server_connection.cpp
@@ -36,6 +36,8 @@ HttpServerConnection::~HttpServerConnection()
   Lock lock(guard_, THIS_LOCATION);
   LOCAL_DEBUG("~HttpServerConnection(%d)", debugFd_);
   detachPollSet(lock);
+  if (socket_)
+    closeSocket();
 }
 
 void HttpServerConnection::setEndpointCollection(const std::shared_ptr<internal::EndpointCollection>& endpoints)
@@ -77,6 +79,11 @@ void HttpServerConnection::attachPollSet(PollSet* poll_set)
           // It resolves issues with lock order, reported by helgrind.
           std::swap(server_lifetime, self->server_lifetime_);
           self->detachPollSet(lock);
+          // Disconnect must FIN the peer so clients waiting in ReadResponse see EOF.
+          // Upgrade transfers socket ownership — do not close it here.
+          if (report.cmd == EventReport::Disconnect) {
+            self->closeSocket();
+          }
         }
         self->updateEventsForSocket(lock);
       }
@@ -140,7 +147,10 @@ Error HttpServerConnection::doReadRequest(Lock& lock)
 
 int HttpServerConnection::fd() const
 {
-  return socket_ ? socket_->fd() : MINIROS_INVALID_SOCKET;
+  // socket_ is cleared under guard_ by closeSocket() on the poll thread;
+  // HttpServer::stop() may call fd() from another thread for logging.
+  Lock lock(guard_, THIS_LOCATION);
+  return socket_ ? socket_->fd() : debugFd_;
 }
 
 bool HttpServerConnection::isDetachedFromParent() const
@@ -588,6 +598,8 @@ int HttpServerConnection::eventsForState(State state) const
 
 void HttpServerConnection::closeSocket()
 {
+  if (!socket_)
+    return;
   socket_->close();
   socket_.reset();
 }

--- a/src/roscore/master.cpp
+++ b/src/roscore/master.cpp
@@ -364,6 +364,11 @@ void Master::update()
     internal_->shutdownNode(nr, ss.str());
   }
 
+  // Drive cache restore before empty-node GC: restored NodeRefs are empty until
+  // getPublications / services are reapplied.
+  const int port = internal_->rpcManager ? internal_->rpcManager->getServerPort() : 0;
+  internal_->cache.update(port, internal_->uuid.toString());
+
   auto graveyard = internal_->regManager.checkNodesForRemoval();
   if (!graveyard.empty()) {
     MINIROS_INFO("Dropping parameter subscriptions from %d nodes", static_cast<int>(graveyard.size()));
@@ -372,9 +377,6 @@ void Master::update()
     }
     internal_->cache.markDirty();
   }
-
-  const int port = internal_->rpcManager ? internal_->rpcManager->getServerPort() : 0;
-  internal_->cache.update(port, internal_->uuid.toString());
 }
 
 Master::RpcValue Master::lookupService(

--- a/src/roscore/master.cpp
+++ b/src/roscore/master.cpp
@@ -24,6 +24,7 @@
 #include "miniros/http/http_filters.h"
 #include "miniros/callback_queue.h"
 #include "miniros/rostime.h"
+#include "miniros/common.h"
 
 namespace miniros {
 
@@ -38,6 +39,7 @@ Master::Internal::Internal(const std::shared_ptr<RPCManager>& manager)
 {
   rpcManager = manager;
   resolver.scanAdapters();
+  cache.bind(&regManager, &handler);
 }
 
 Master::Internal::~Internal()
@@ -121,9 +123,24 @@ bool Master::start(PollSet* poll_set, int port)
   setupBindings(cb);
   internal_->callbackQueue = cb;
 
-  // It was done in roslaunch by calling generate_run_id() function.
-  // It should be uuid.uuid1()
-  internal_->uuid.generate();
+  // Prefer a persisted instance GUID when caching is enabled.
+  bool guidFromCache = false;
+  if (internal_->cache.enabled()) {
+    if (Error err = internal_->cache.load(port); !err) {
+      MINIROS_WARN("MasterCache: load failed: %s", err.toString());
+    } else if (!internal_->cache.guid().empty()) {
+      if (internal_->uuid.fromString(internal_->cache.guid())) {
+        guidFromCache = true;
+        MINIROS_INFO("Restored master GUID %s from cache", internal_->cache.guid().c_str());
+      } else {
+        MINIROS_WARN("Ignoring invalid GUID in cache: %s", internal_->cache.guid().c_str());
+      }
+    }
+  }
+  if (!guidFromCache) {
+    // It was done in roslaunch by calling generate_run_id() function.
+    internal_->uuid.generate();
+  }
   internal_->parameterStorage.setParam("master", "/run_id", internal_->uuid.toString());
 
   internal_->rpcManager->setPollSet(poll_set);
@@ -131,6 +148,12 @@ bool Master::start(PollSet* poll_set, int port)
 
   if (!internal_->rpcManager->start(cb, port)) {
     return false;
+  }
+
+  // Use the already-loaded snapshot; bound port only updates the save path.
+  const int boundPort = internal_->rpcManager->getServerPort();
+  if (internal_->cache.enabled()) {
+    internal_->cache.beginRestore(boundPort > 0 ? boundPort : port, internal_->uuid.toString());
   }
 
   if (internal_->discovery) {
@@ -156,7 +179,11 @@ bool Master::start(PollSet* poll_set, int port)
 
 void Master::stop()
 {
-  if (internal_ && internal_->rpcManager)
+  if (!internal_)
+    return;
+  const int port = internal_->rpcManager ? internal_->rpcManager->getServerPort() : 0;
+  internal_->cache.flush(port, internal_->uuid.toString());
+  if (internal_->rpcManager)
     internal_->rpcManager->shutdown();
 }
 
@@ -245,6 +272,13 @@ void Master::setNodeCheckPeriod(double seconds)
                seconds, seconds <= 0 ? " (disabled)" : "");
 }
 
+void Master::setCacheEnabled(bool enabled)
+{
+  if (!internal_)
+    return;
+  internal_->cache.setEnabled(enabled);
+}
+
 void Master::Internal::checkNodesAlive()
 {
   auto nodes = regManager.listAllNodes();
@@ -301,6 +335,7 @@ void Master::Internal::shutdownNode(const std::shared_ptr<NodeRef>& node, const 
   }
 
   node->markDead();
+  cache.markDirty();
 }
 
 void Master::update()
@@ -335,7 +370,11 @@ void Master::update()
     for (auto node: graveyard) {
       internal_->parameterStorage.dropSubscriptions(node);
     }
+    internal_->cache.markDirty();
   }
+
+  const int port = internal_->rpcManager ? internal_->rpcManager->getServerPort() : 0;
+  internal_->cache.update(port, internal_->uuid.toString());
 }
 
 Master::RpcValue Master::lookupService(
@@ -370,6 +409,8 @@ Master::RpcValue Master::registerService(const std::string& caller_id, const std
   requesterInfo.callerApi = caller_api;
 
   ReturnStruct r = internal_->handler.registerService(requesterInfo, service, service_api);
+  if (r.statusCode == 1)
+    internal_->cache.markDirty();
 
   RpcValue res = RpcValue::Array(3);
   res[0] = r.statusCode;
@@ -386,6 +427,8 @@ Master::RpcValue Master::unregisterService(const std::string& caller_id, const s
     MINIROS_WARN("Failed to read network address of caller %s", caller_id.c_str());
   }
   ReturnStruct r = internal_->handler.unregisterService(requesterInfo, service, service_api);
+  if (r.statusCode == 1)
+    internal_->cache.markDirty();
 
   RpcValue res = RpcValue::Array(3);
   res[0] = r.statusCode;
@@ -492,6 +535,8 @@ Master::RpcValue Master::registerPublisher(const std::string& caller_id, const s
   requesterInfo.callerApi = caller_api;
 
   ReturnStruct st = internal_->handler.registerPublisher(requesterInfo, topic, type);
+  if (st.statusCode == 1)
+    internal_->cache.markDirty();
   RpcValue res = RpcValue::Array(3);
   res[0] = st.statusCode;
   res[1] = st.statusMessage;
@@ -509,6 +554,8 @@ Master::RpcValue Master::unregisterPublisher(
   requesterInfo.callerApi = caller_api;
 
   ReturnStruct st = internal_->handler.unregisterPublisher(requesterInfo, topic);
+  if (st.statusCode == 1)
+    internal_->cache.markDirty();
   RpcValue res = RpcValue::Array(3);
   res[0] = st.statusCode;
   res[1] = st.statusMessage;
@@ -526,6 +573,8 @@ Master::RpcValue Master::registerSubscriber(const std::string& caller_id, const 
   requesterInfo.callerApi = caller_api;
 
   ReturnStruct st = internal_->handler.registerSubscriber(requesterInfo, topic, type);
+  if (st.statusCode == 1)
+    internal_->cache.markDirty();
   RpcValue res = RpcValue::Array(3);
   res[0] = st.statusCode;
   res[1] = st.statusMessage;
@@ -543,6 +592,8 @@ Master::RpcValue Master::unregisterSubscriber(const std::string& caller_id, cons
   requesterInfo.callerApi = caller_api;
 
   ReturnStruct st = internal_->handler.unregisterSubscriber(requesterInfo, topic);
+  if (st.statusCode == 1)
+    internal_->cache.markDirty();
   RpcValue res = RpcValue::Array(3);
   res[0] = st.statusCode;
   res[1] = st.statusMessage;

--- a/src/roscore/master.h
+++ b/src/roscore/master.h
@@ -83,6 +83,9 @@ public:
   /// @param seconds - check interval in seconds; 0 disables periodic checks.
   void setNodeCheckPeriod(double seconds);
 
+  /// Enable or disable persistent state (cache.<port> in the current working directory).
+  void setCacheEnabled(bool enabled);
+
   /// Update queued tasks.
   void update();
 

--- a/src/roscore/master_cache.cpp
+++ b/src/roscore/master_cache.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 #if !defined(_WIN32)
 #include <fcntl.h>
@@ -342,14 +343,26 @@ MasterCacheData MasterCache::collect(int port, const std::string& guid) const
     cn.pid = node->pid();
     cn.state = node->getState().toString();
 
-    std::unique_lock nodeLock(*node);
-    const auto& services = node->getServicesUnsafe();
-    for (const std::string& svcName : services) {
-      CachedService svc;
-      svc.name = svcName;
-      svc.service_api = regs_->services.get_service_api(svcName);
-      if (!svc.service_api.empty())
-        cn.services.push_back(std::move(svc));
+    // Copy service names under the node lock, then resolve APIs under the
+    // RegistrationManager lock. Do not hold both at once (register takes
+    // m_guard then the node lock). Reading services.service_api_map without
+    // m_guard races with register/unregister and can yield torn UTF-8 strings
+    // that abort nlohmann::json::dump().
+    std::vector<std::string> serviceNames;
+    {
+      std::unique_lock nodeLock(*node);
+      const auto& services = node->getServicesUnsafe();
+      serviceNames.assign(services.begin(), services.end());
+    }
+    {
+      RegistrationManager::Lock regLock(*regs_);
+      for (const std::string& svcName : serviceNames) {
+        CachedService svc;
+        svc.name = svcName;
+        svc.service_api = regs_->services.get_service_api(svcName);
+        if (!svc.service_api.empty())
+          cn.services.push_back(std::move(svc));
+      }
     }
 
     data.nodes.push_back(std::move(cn));
@@ -669,7 +682,15 @@ Error MasterCache::saveFile(const std::filesystem::path& path, const MasterCache
     root["nodes"].push_back(std::move(nodeJson));
   }
 
-  const std::string payload = root.dump(2) + "\n";
+  std::string payload;
+  try {
+    // replace: never abort the master on a stray non-UTF-8 byte in a name/URI.
+    payload = root.dump(2, ' ', false, json::error_handler_t::replace) + "\n";
+  } catch (const json::exception& e) {
+    setDetail(std::string("json dump failed: ") + e.what());
+    return Error::InvalidValue;
+  }
+
   if (Error err = writeAtomically(path, payload, detail); !err)
     return err;
 

--- a/src/roscore/master_cache.cpp
+++ b/src/roscore/master_cache.cpp
@@ -36,7 +36,7 @@ void MasterCache::setEnabled(bool enabled)
 
 void MasterCache::markDirty()
 {
-  dirty_ = true;
+  dirty_.store(true, std::memory_order_release);
 }
 
 std::filesystem::path MasterCache::pathForPort(const std::filesystem::path& dir, int port)
@@ -70,16 +70,16 @@ void MasterCache::beginRestore(int port, const std::string& runtimeGuid)
     path_ = pathForPort(".", port);
 
   if (!loaded_) {
-    dirty_ = true;
+    dirty_.store(true, std::memory_order_relaxed);
     return;
   }
 
   if (data_.guid.empty() || data_.guid != runtimeGuid)
-    dirty_ = true;
+    dirty_.store(true, std::memory_order_relaxed);
 
   if (data_.nodes.empty()) {
     MINIROS_INFO("MasterCache: no nodes to restore from \"%s\"", path_.string().c_str());
-    dirty_ = true;
+    dirty_.store(true, std::memory_order_relaxed);
     saveIfNeeded(port, runtimeGuid);
     return;
   }
@@ -138,7 +138,7 @@ void MasterCache::update(int port, const std::string& guid)
 
 void MasterCache::flush(int port, const std::string& guid)
 {
-  dirty_ = true;
+  dirty_.store(true, std::memory_order_release);
   saveIfNeeded(port, guid);
 }
 
@@ -309,7 +309,7 @@ void MasterCache::finalizeRestore()
   }
 
   MINIROS_INFO("MasterCache: restore complete");
-  dirty_ = true;
+  dirty_.store(true, std::memory_order_relaxed);
 }
 
 MasterCacheData MasterCache::collect(int port, const std::string& guid) const
@@ -352,7 +352,12 @@ MasterCacheData MasterCache::collect(int port, const std::string& guid) const
 
 void MasterCache::saveIfNeeded(int port, const std::string& guid)
 {
-  if (!dirty_ || !enabled_ || restoring_)
+  // Skip while disabled or mid-restore; leave dirty_ set so a later update flushes.
+  if (!enabled_ || restoring_)
+    return;
+
+  // Clear the flag before IO so concurrent markDirty() during save is not lost.
+  if (!dirty_.exchange(false, std::memory_order_acq_rel))
     return;
 
   if (port <= 0 && !path_.empty()) {
@@ -361,11 +366,13 @@ void MasterCache::saveIfNeeded(int port, const std::string& guid)
     path_ = pathForPort(".", port);
   }
 
-  if (path_.empty())
+  if (path_.empty()) {
+    dirty_.store(true, std::memory_order_relaxed);
     return;
+  }
 
-  if (saveFile(path_, collect(port, guid)))
-    dirty_ = false;
+  if (!saveFile(path_, collect(port, guid)))
+    dirty_.store(true, std::memory_order_relaxed);
 }
 
 Error MasterCache::loadFile(const std::filesystem::path& path, MasterCacheData& out)

--- a/src/roscore/master_cache.cpp
+++ b/src/roscore/master_cache.cpp
@@ -12,10 +12,17 @@
 #include "miniros/console.h"
 #include "miniros/internal/nlohmann_json.hpp"
 
+#include <cerrno>
+#include <cstring>
 #include <fstream>
 #include <memory>
 #include <system_error>
 #include <utility>
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 namespace miniros {
 namespace master {
@@ -368,11 +375,50 @@ void MasterCache::saveIfNeeded(int port, const std::string& guid)
 
   if (path_.empty()) {
     dirty_.store(true, std::memory_order_relaxed);
+    noteSaveResult(Error::InvalidValue, "empty cache path");
     return;
   }
 
-  if (!saveFile(path_, collect(port, guid)))
+  std::string detail;
+  const Error err = saveFile(path_, collect(port, guid), &detail);
+  if (!err) {
+    // Keep dirty so we retry after disk-full / read-only / power-loss style failures.
     dirty_.store(true, std::memory_order_relaxed);
+    noteSaveResult(err, detail.empty() ? std::string(err.toString()) : detail);
+    return;
+  }
+  noteSaveResult(Error::Ok, detail);
+}
+
+void MasterCache::noteSaveResult(Error err, const std::string& detail)
+{
+  if (err) {
+    if (saveFailCount_ > 0) {
+      MINIROS_INFO("MasterCache: save recovered after %d failure(s)%s%s",
+                   saveFailCount_,
+                   detail.empty() ? "" : ": ",
+                   detail.c_str());
+    }
+    saveFailCount_ = 0;
+    lastSaveError_.clear();
+    return;
+  }
+
+  ++saveFailCount_;
+  lastSaveError_ = detail;
+
+  // Log the first failure immediately, then at most once every 30s while it persists.
+  const SteadyTime now = SteadyTime::now();
+  const bool first = (saveFailCount_ == 1);
+  const bool due = first || (now - lastSaveErrorLog_ > WallDuration(30.0));
+  if (!due)
+    return;
+
+  lastSaveErrorLog_ = now;
+  MINIROS_ERROR("MasterCache: failed to persist state (attempt %d): %s — will retry; "
+                "graph updates may be lost across an unclean master restart",
+                saveFailCount_,
+                detail.empty() ? err.toString() : detail.c_str());
 }
 
 Error MasterCache::loadFile(const std::filesystem::path& path, MasterCacheData& out)
@@ -380,13 +426,33 @@ Error MasterCache::loadFile(const std::filesystem::path& path, MasterCacheData& 
   out = MasterCacheData{};
 
   std::error_code ec;
+  const std::filesystem::path tmpPath = path.string() + ".tmp";
+  if (std::filesystem::exists(tmpPath, ec) && !ec) {
+    MINIROS_WARN("MasterCache: found leftover \"%s\" (previous save may have been "
+                 "interrupted by power loss or a full/read-only disk); ignoring it",
+                 tmpPath.string().c_str());
+  }
+
   if (!std::filesystem::exists(path, ec) || ec) {
     return Error::Ok;
   }
 
+  const auto fileSize = std::filesystem::file_size(path, ec);
+  if (ec) {
+    MINIROS_ERROR("MasterCache: cannot stat \"%s\": %s", path.string().c_str(), ec.message().c_str());
+    return Error::SystemError;
+  }
+  if (fileSize == 0) {
+    MINIROS_ERROR("MasterCache: \"%s\" is empty (truncated or interrupted write?); starting without cache",
+                  path.string().c_str());
+    return Error::InvalidValue;
+  }
+
   std::ifstream in(path);
   if (!in.is_open()) {
-    MINIROS_WARN("MasterCache: failed to open \"%s\" for reading", path.string().c_str());
+    const int saved = errno;
+    MINIROS_ERROR("MasterCache: failed to open \"%s\" for reading: %s (errno=%d)",
+                  path.string().c_str(), std::strerror(saved), saved);
     return Error::SystemError;
   }
 
@@ -394,12 +460,15 @@ Error MasterCache::loadFile(const std::filesystem::path& path, MasterCacheData& 
   try {
     in >> root;
   } catch (const json::exception& e) {
-    MINIROS_WARN("MasterCache: failed to parse \"%s\": %s", path.string().c_str(), e.what());
+    MINIROS_ERROR("MasterCache: corrupt/incomplete \"%s\" (%zu bytes): %s — "
+                  "starting without cache (power loss mid-write?)",
+                  path.string().c_str(), static_cast<size_t>(fileSize), e.what());
     return Error::InvalidValue;
   }
 
   if (!root.is_object()) {
-    MINIROS_WARN("MasterCache: root is not an object in \"%s\"", path.string().c_str());
+    MINIROS_ERROR("MasterCache: root is not an object in \"%s\"; starting without cache",
+                  path.string().c_str());
     return Error::InvalidValue;
   }
 
@@ -444,14 +513,138 @@ Error MasterCache::loadFile(const std::filesystem::path& path, MasterCacheData& 
   return Error::Ok;
 }
 
-Error MasterCache::saveFile(const std::filesystem::path& path, const MasterCacheData& data)
+namespace {
+
+std::string errnoDetail(const char* op, const std::filesystem::path& path, int err)
 {
+  std::string msg = std::string(op) + " \"" + path.string() + "\": " + std::strerror(err)
+                    + " (errno=" + std::to_string(err) + ")";
+  if (err == ENOSPC
+#ifdef EDQUOT
+      || err == EDQUOT
+#endif
+  ) {
+    msg += " [disk full or quota exceeded]";
+  } else if (err == EROFS) {
+    msg += " [filesystem is read-only]";
+  } else if (err == EACCES || err == EPERM) {
+    msg += " [permission denied]";
+  }
+  return msg;
+}
+
+Error writeAtomically(const std::filesystem::path& path, const std::string& payload, std::string* detail)
+{
+  auto setDetail = [&](std::string msg) {
+    if (detail)
+      *detail = std::move(msg);
+  };
+
+  const std::filesystem::path tmp = path.string() + ".tmp";
+  std::error_code ec;
+  // Drop a stale temp from a previous interrupted attempt before rewriting.
+  std::filesystem::remove(tmp, ec);
+
+#if defined(_WIN32)
+  {
+    std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+    if (!out.is_open()) {
+      setDetail("open \"" + tmp.string() + "\" for writing failed");
+      return Error::SystemError;
+    }
+    out.write(payload.data(), static_cast<std::streamsize>(payload.size()));
+    out.flush();
+    if (!out.good()) {
+      setDetail("write \"" + tmp.string() + "\" failed");
+      out.close();
+      std::filesystem::remove(tmp, ec);
+      return Error::SystemError;
+    }
+  }
+#else
+  // POSIX: open/write/fsync/close so a power cut cannot leave a half-written final file
+  // (final replace is rename below). ENOSPC/EROFS surface with clear errno tags.
+  const int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
+  if (fd < 0) {
+    setDetail(errnoDetail("open", tmp, errno));
+    return Error::SystemError;
+  }
+
+  const char* buf = payload.data();
+  size_t remaining = payload.size();
+  while (remaining > 0) {
+    const ssize_t n = ::write(fd, buf, remaining);
+    if (n < 0) {
+      if (errno == EINTR)
+        continue;
+      const int saved = errno;
+      ::close(fd);
+      std::filesystem::remove(tmp, ec);
+      setDetail(errnoDetail("write", tmp, saved));
+      return Error::SystemError;
+    }
+    buf += n;
+    remaining -= static_cast<size_t>(n);
+  }
+
+  if (::fsync(fd) != 0) {
+    const int saved = errno;
+    ::close(fd);
+    std::filesystem::remove(tmp, ec);
+    setDetail(errnoDetail("fsync", tmp, saved));
+    return Error::SystemError;
+  }
+  if (::close(fd) != 0) {
+    const int saved = errno;
+    std::filesystem::remove(tmp, ec);
+    setDetail(errnoDetail("close", tmp, saved));
+    return Error::SystemError;
+  }
+#endif
+
+  std::filesystem::rename(tmp, path, ec);
+  if (ec) {
+#if defined(_WIN32)
+    setDetail("rename \"" + tmp.string() + "\" → \"" + path.string() + "\": " + ec.message());
+#else
+    // Prefer errno-tagged message when the generic category carries an errno value.
+    const int err = (ec.category() == std::system_category()) ? ec.value() : EIO;
+    setDetail(errnoDetail("rename", path, err) + " (from \"" + tmp.string() + "\")");
+#endif
+    std::filesystem::remove(tmp, ec);
+    return Error::SystemError;
+  }
+
+#if !defined(_WIN32)
+  // Best-effort: durable directory entry for the rename itself.
+  const auto parent = path.parent_path().empty() ? std::filesystem::path(".") : path.parent_path();
+  const int dirfd = ::open(parent.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  if (dirfd >= 0) {
+    if (::fsync(dirfd) != 0) {
+      MINIROS_WARN("MasterCache: %s", errnoDetail("fsync(dir)", parent, errno).c_str());
+    }
+    ::close(dirfd);
+  }
+#endif
+
+  return Error::Ok;
+}
+
+} // namespace
+
+Error MasterCache::saveFile(const std::filesystem::path& path, const MasterCacheData& data,
+                            std::string* detail)
+{
+  auto setDetail = [&](std::string msg) {
+    if (detail)
+      *detail = std::move(msg);
+  };
+
   std::error_code ec;
   const auto parent = path.parent_path();
   if (!parent.empty() && !std::filesystem::exists(parent, ec)) {
     if (!std::filesystem::create_directories(parent, ec) && ec) {
-      MINIROS_WARN("MasterCache: failed to create \"%s\": %s",
-                   parent.string().c_str(), ec.message().c_str());
+      setDetail("create_directories \"" + parent.string() + "\": " + ec.message());
       return Error::SystemError;
     }
   }
@@ -476,29 +669,12 @@ Error MasterCache::saveFile(const std::filesystem::path& path, const MasterCache
     root["nodes"].push_back(std::move(nodeJson));
   }
 
-  const std::filesystem::path tmp = path.string() + ".tmp";
-  {
-    std::ofstream out(tmp, std::ios::trunc);
-    if (!out.is_open()) {
-      MINIROS_WARN("MasterCache: failed to open \"%s\" for writing", tmp.string().c_str());
-      return Error::SystemError;
-    }
-    out << root.dump(2) << '\n';
-    if (!out.good()) {
-      MINIROS_WARN("MasterCache: write failed for \"%s\"", tmp.string().c_str());
-      return Error::SystemError;
-    }
-  }
-
-  std::filesystem::rename(tmp, path, ec);
-  if (ec) {
-    MINIROS_WARN("MasterCache: rename \"%s\" → \"%s\" failed: %s",
-                 tmp.string().c_str(), path.string().c_str(), ec.message().c_str());
-    std::filesystem::remove(tmp, ec);
-    return Error::SystemError;
-  }
+  const std::string payload = root.dump(2) + "\n";
+  if (Error err = writeAtomically(path, payload, detail); !err)
+    return err;
 
   MINIROS_DEBUG("MasterCache: saved \"%s\" (nodes=%zu)", path.string().c_str(), data.nodes.size());
+  setDetail("saved " + path.string());
   return Error::Ok;
 }
 

--- a/src/roscore/master_cache.cpp
+++ b/src/roscore/master_cache.cpp
@@ -1,0 +1,499 @@
+//
+// Persistent state for miniroscore across restarts.
+//
+
+#include "master_cache.h"
+
+#include "master_handler.h"
+#include "node_ref.h"
+#include "registration_manager.h"
+
+#include "miniros/common.h"
+#include "miniros/console.h"
+#include "miniros/internal/nlohmann_json.hpp"
+
+#include <fstream>
+#include <memory>
+#include <system_error>
+#include <utility>
+
+namespace miniros {
+namespace master {
+
+using json = nlohmann::json;
+
+void MasterCache::bind(RegistrationManager* regs, MasterHandler* handler)
+{
+  regs_ = regs;
+  handler_ = handler;
+}
+
+void MasterCache::setEnabled(bool enabled)
+{
+  enabled_ = enabled;
+  MINIROS_INFO("Master cache %s (file cache.<port> in cwd)", enabled ? "enabled" : "disabled");
+}
+
+void MasterCache::markDirty()
+{
+  dirty_ = true;
+}
+
+std::filesystem::path MasterCache::pathForPort(const std::filesystem::path& dir, int port)
+{
+  return dir / ("cache." + std::to_string(port));
+}
+
+Error MasterCache::load(int port)
+{
+  data_ = MasterCacheData{};
+  loaded_ = false;
+  if (!enabled_)
+    return Error::Ok;
+
+  path_ = pathForPort(".", port);
+  Error err = loadFile(path_, data_);
+  if (!err)
+    return err;
+
+  loaded_ = true;
+  return Error::Ok;
+}
+
+void MasterCache::beginRestore(int port, const std::string& runtimeGuid)
+{
+  if (!enabled_ || !regs_)
+    return;
+
+  // Prefer the bound port for subsequent writes.
+  if (port > 0)
+    path_ = pathForPort(".", port);
+
+  if (!loaded_) {
+    dirty_ = true;
+    return;
+  }
+
+  if (data_.guid.empty() || data_.guid != runtimeGuid)
+    dirty_ = true;
+
+  if (data_.nodes.empty()) {
+    MINIROS_INFO("MasterCache: no nodes to restore from \"%s\"", path_.string().c_str());
+    dirty_ = true;
+    saveIfNeeded(port, runtimeGuid);
+    return;
+  }
+
+  restoring_ = true;
+  restoreDeadline_ = SteadyTime::now() + WallDuration(15.0);
+  size_t started = 0;
+
+  for (const CachedNode& cn : data_.nodes) {
+    if (cn.name.empty() || cn.api.empty())
+      continue;
+
+    NodeRef::State cachedState;
+    if (!cn.state.empty() && cachedState.fromString(cn.state)) {
+      if (cachedState == NodeRef::State::Dead || cachedState == NodeRef::State::ShuttingDown) {
+        MINIROS_INFO("MasterCache: skipping %s (cached state=%s)",
+                     cn.name.c_str(), cn.state.c_str());
+        continue;
+      }
+    }
+
+    if (cn.pid > 0 && !isProcessAlive(cn.pid)) {
+      MINIROS_INFO("MasterCache: skipping dead process %s pid=%d", cn.name.c_str(), cn.pid);
+      continue;
+    }
+
+    auto report = regs_->registerNodeApi(cn.name, cn.api, 0);
+    if (!report.node) {
+      MINIROS_WARN("MasterCache: failed to register restored node %s", cn.name.c_str());
+      continue;
+    }
+
+    std::vector<std::pair<std::string, std::string>> services;
+    services.reserve(cn.services.size());
+    for (const CachedService& svc : cn.services)
+      services.emplace_back(svc.name, svc.service_api);
+    report.node->beginRestore(std::move(services));
+    ++started;
+    MINIROS_INFO("MasterCache: restoring node %s at %s (pid=%d cached_state=%s)",
+                 cn.name.c_str(), cn.api.c_str(), cn.pid,
+                 cn.state.empty() ? "?" : cn.state.c_str());
+  }
+
+  // Snapshot nodes are consumed; keep guid for dirty comparisons until next save.
+  data_.nodes.clear();
+
+  if (started == 0)
+    finalizeRestore();
+}
+
+void MasterCache::update(int port, const std::string& guid)
+{
+  processRestore();
+  saveIfNeeded(port, guid);
+}
+
+void MasterCache::flush(int port, const std::string& guid)
+{
+  dirty_ = true;
+  saveIfNeeded(port, guid);
+}
+
+void MasterCache::processRestore()
+{
+  if (!restoring_ || !regs_ || !handler_)
+    return;
+
+  std::vector<PendingTopicRestore> pending;
+  {
+    std::lock_guard lock(restoreMutex_);
+    pending.swap(pendingTopicRestores_);
+  }
+  for (auto& item : pending) {
+    applyTopicList(item.nodeName, item.nodeApi, item.publications, item.code, item.data);
+  }
+
+  bool anyInProgress = false;
+  for (const auto& node : regs_->listAllNodes()) {
+    if (!node || !node->isRestoreInProgress())
+      continue;
+
+    const auto state = node->getState();
+    if (state == NodeRef::State::Dead || state == NodeRef::State::ShuttingDown)
+      continue;
+
+    anyInProgress = true;
+
+    if (state == NodeRef::State::Restoring)
+      continue;
+    if (state == NodeRef::State::Recovering && node->restoreQueriesLeft() > 0)
+      continue;
+    if (state != NodeRef::State::Recovering)
+      continue;
+
+    const std::string name = node->id();
+    const std::string api = node->getApi();
+    node->beginTopicRecovery(2);
+    restoreServices(node);
+
+    int left = 2;
+    if (Error err = node->sendGetPublications("/master",
+      [this, name, api](int code, const std::string& /*msg*/, const RpcValue& data) {
+        queueTopicList(name, api, true, code, data);
+      }); !err) {
+      MINIROS_WARN("MasterCache: getPublications(%s) failed: %s", name.c_str(), err.toString());
+      --left;
+      node->notifyRestoreQueryDone();
+    }
+
+    if (Error err = node->sendGetSubscriptions("/master",
+      [this, name, api](int code, const std::string& /*msg*/, const RpcValue& data) {
+        queueTopicList(name, api, false, code, data);
+      }); !err) {
+      MINIROS_WARN("MasterCache: getSubscriptions(%s) failed: %s", name.c_str(), err.toString());
+      --left;
+      node->notifyRestoreQueryDone();
+    }
+
+    if (left <= 0)
+      anyInProgress = node->isRestoreInProgress();
+  }
+
+  if (!anyInProgress) {
+    for (const auto& node : regs_->listAllNodes()) {
+      if (node && node->isRestoreInProgress()) {
+        anyInProgress = true;
+        break;
+      }
+    }
+  }
+
+  const bool timedOut = !restoreDeadline_.isZero() && SteadyTime::now() >= restoreDeadline_;
+  if (!anyInProgress || timedOut) {
+    if (timedOut && anyInProgress)
+      MINIROS_WARN("MasterCache: restore timed out");
+    finalizeRestore();
+  }
+}
+
+void MasterCache::queueTopicList(const std::string& nodeName, const std::string& nodeApi,
+  bool publications, int code, const RpcValue& data)
+{
+  PendingTopicRestore item;
+  item.nodeName = nodeName;
+  item.nodeApi = nodeApi;
+  item.publications = publications;
+  item.code = code;
+  item.data = data;
+  std::lock_guard lock(restoreMutex_);
+  pendingTopicRestores_.push_back(std::move(item));
+}
+
+void MasterCache::applyTopicList(const std::string& nodeName, const std::string& nodeApi,
+  bool publications, int code, const RpcValue& data)
+{
+  if (!restoring_ || !regs_ || !handler_)
+    return;
+
+  auto node = regs_->getNodeByName(nodeName);
+  if (!node)
+    return;
+
+  if (code == 1 && data.getType() == XmlRpc::XmlRpcValue::TypeArray) {
+    for (int i = 0; i < data.size(); ++i) {
+      const RpcValue& entry = data[i];
+      if (entry.getType() != XmlRpc::XmlRpcValue::TypeArray || entry.size() < 2)
+        continue;
+      const std::string topic = static_cast<std::string>(entry[0]);
+      const std::string type = static_cast<std::string>(entry[1]);
+      if (topic.empty() || type.empty())
+        continue;
+
+      if (publications)
+        regs_->register_publisher(topic, type, nodeName, nodeApi);
+      else
+        regs_->register_subscriber(topic, type, nodeName, nodeApi);
+
+      auto subscribers = regs_->getTopicSubscribers(topic);
+      handler_->notifyTopicSubscribers(topic, subscribers);
+
+      MINIROS_INFO("MasterCache: restored %s %s type=%s on %s",
+                   publications ? "publisher" : "subscriber",
+                   topic.c_str(), type.c_str(), nodeName.c_str());
+    }
+  } else {
+    MINIROS_WARN("MasterCache: %s response for %s failed code=%d",
+                 publications ? "getPublications" : "getSubscriptions",
+                 nodeName.c_str(), code);
+  }
+
+  node->notifyRestoreQueryDone();
+}
+
+void MasterCache::restoreServices(const std::shared_ptr<NodeRef>& node)
+{
+  if (!node || !regs_)
+    return;
+  const std::string nodeName = node->id();
+  const std::string nodeApi = node->getApi();
+  for (const auto& [svcName, serviceApi] : node->takePendingRestoreServices()) {
+    if (svcName.empty() || serviceApi.empty())
+      continue;
+    regs_->register_service(svcName, nodeName, nodeApi, serviceApi);
+    MINIROS_INFO("MasterCache: restored service %s (%s) on %s",
+                 svcName.c_str(), serviceApi.c_str(), nodeName.c_str());
+  }
+}
+
+void MasterCache::finalizeRestore()
+{
+  if (!restoring_)
+    return;
+
+  restoring_ = false;
+  if (!regs_)
+    return;
+
+  for (const auto& node : regs_->listAllNodes()) {
+    if (!node || !node->isRestoreInProgress())
+      continue;
+    if (node->getState() == NodeRef::State::Restoring)
+      regs_->scheduleShutdown(node);
+    else {
+      while (!node->notifyRestoreQueryDone()) {
+      }
+    }
+  }
+
+  MINIROS_INFO("MasterCache: restore complete");
+  dirty_ = true;
+}
+
+MasterCacheData MasterCache::collect(int port, const std::string& guid) const
+{
+  MasterCacheData data;
+  data.guid = guid;
+  data.port = port;
+  if (!regs_)
+    return data;
+
+  for (const auto& node : regs_->listAllNodes()) {
+    if (!node)
+      continue;
+    const int flags = node->getNodeFlags();
+    if (flags & (NodeRef::NODE_LOCAL | NodeRef::NODE_MASTER))
+      continue;
+    if (node->getState() == NodeRef::State::Dead)
+      continue;
+
+    CachedNode cn;
+    cn.name = node->id();
+    cn.api = node->getApi();
+    cn.pid = node->pid();
+    cn.state = node->getState().toString();
+
+    std::unique_lock nodeLock(*node);
+    const auto& services = node->getServicesUnsafe();
+    for (const std::string& svcName : services) {
+      CachedService svc;
+      svc.name = svcName;
+      svc.service_api = regs_->services.get_service_api(svcName);
+      if (!svc.service_api.empty())
+        cn.services.push_back(std::move(svc));
+    }
+
+    data.nodes.push_back(std::move(cn));
+  }
+  return data;
+}
+
+void MasterCache::saveIfNeeded(int port, const std::string& guid)
+{
+  if (!dirty_ || !enabled_ || restoring_)
+    return;
+
+  if (port <= 0 && !path_.empty()) {
+    // Keep previous path if port is temporarily unavailable.
+  } else {
+    path_ = pathForPort(".", port);
+  }
+
+  if (path_.empty())
+    return;
+
+  if (saveFile(path_, collect(port, guid)))
+    dirty_ = false;
+}
+
+Error MasterCache::loadFile(const std::filesystem::path& path, MasterCacheData& out)
+{
+  out = MasterCacheData{};
+
+  std::error_code ec;
+  if (!std::filesystem::exists(path, ec) || ec) {
+    return Error::Ok;
+  }
+
+  std::ifstream in(path);
+  if (!in.is_open()) {
+    MINIROS_WARN("MasterCache: failed to open \"%s\" for reading", path.string().c_str());
+    return Error::SystemError;
+  }
+
+  json root;
+  try {
+    in >> root;
+  } catch (const json::exception& e) {
+    MINIROS_WARN("MasterCache: failed to parse \"%s\": %s", path.string().c_str(), e.what());
+    return Error::InvalidValue;
+  }
+
+  if (!root.is_object()) {
+    MINIROS_WARN("MasterCache: root is not an object in \"%s\"", path.string().c_str());
+    return Error::InvalidValue;
+  }
+
+  if (root.contains("guid") && root["guid"].is_string())
+    out.guid = root["guid"].get<std::string>();
+  if (root.contains("port") && root["port"].is_number_integer())
+    out.port = root["port"].get<int>();
+
+  if (root.contains("nodes") && root["nodes"].is_array()) {
+    for (const auto& nodeJson : root["nodes"]) {
+      if (!nodeJson.is_object())
+        continue;
+      CachedNode node;
+      if (nodeJson.contains("name") && nodeJson["name"].is_string())
+        node.name = nodeJson["name"].get<std::string>();
+      if (nodeJson.contains("api") && nodeJson["api"].is_string())
+        node.api = nodeJson["api"].get<std::string>();
+      if (nodeJson.contains("pid") && nodeJson["pid"].is_number_integer())
+        node.pid = nodeJson["pid"].get<int>();
+      if (nodeJson.contains("state") && nodeJson["state"].is_string())
+        node.state = nodeJson["state"].get<std::string>();
+      if (nodeJson.contains("services") && nodeJson["services"].is_array()) {
+        for (const auto& svcJson : nodeJson["services"]) {
+          if (!svcJson.is_object())
+            continue;
+          CachedService svc;
+          if (svcJson.contains("name") && svcJson["name"].is_string())
+            svc.name = svcJson["name"].get<std::string>();
+          if (svcJson.contains("api") && svcJson["api"].is_string())
+            svc.service_api = svcJson["api"].get<std::string>();
+          if (!svc.name.empty() && !svc.service_api.empty())
+            node.services.push_back(std::move(svc));
+        }
+      }
+      if (!node.name.empty() && !node.api.empty())
+        out.nodes.push_back(std::move(node));
+    }
+  }
+
+  MINIROS_INFO("MasterCache: loaded \"%s\" (guid=%s nodes=%zu)",
+               path.string().c_str(), out.guid.c_str(), out.nodes.size());
+  return Error::Ok;
+}
+
+Error MasterCache::saveFile(const std::filesystem::path& path, const MasterCacheData& data)
+{
+  std::error_code ec;
+  const auto parent = path.parent_path();
+  if (!parent.empty() && !std::filesystem::exists(parent, ec)) {
+    if (!std::filesystem::create_directories(parent, ec) && ec) {
+      MINIROS_WARN("MasterCache: failed to create \"%s\": %s",
+                   parent.string().c_str(), ec.message().c_str());
+      return Error::SystemError;
+    }
+  }
+
+  json root;
+  root["guid"] = data.guid;
+  root["port"] = data.port;
+  root["nodes"] = json::array();
+  for (const CachedNode& node : data.nodes) {
+    json nodeJson;
+    nodeJson["name"] = node.name;
+    nodeJson["api"] = node.api;
+    nodeJson["pid"] = node.pid;
+    nodeJson["state"] = node.state;
+    nodeJson["services"] = json::array();
+    for (const CachedService& svc : node.services) {
+      json svcJson;
+      svcJson["name"] = svc.name;
+      svcJson["api"] = svc.service_api;
+      nodeJson["services"].push_back(std::move(svcJson));
+    }
+    root["nodes"].push_back(std::move(nodeJson));
+  }
+
+  const std::filesystem::path tmp = path.string() + ".tmp";
+  {
+    std::ofstream out(tmp, std::ios::trunc);
+    if (!out.is_open()) {
+      MINIROS_WARN("MasterCache: failed to open \"%s\" for writing", tmp.string().c_str());
+      return Error::SystemError;
+    }
+    out << root.dump(2) << '\n';
+    if (!out.good()) {
+      MINIROS_WARN("MasterCache: write failed for \"%s\"", tmp.string().c_str());
+      return Error::SystemError;
+    }
+  }
+
+  std::filesystem::rename(tmp, path, ec);
+  if (ec) {
+    MINIROS_WARN("MasterCache: rename \"%s\" → \"%s\" failed: %s",
+                 tmp.string().c_str(), path.string().c_str(), ec.message().c_str());
+    std::filesystem::remove(tmp, ec);
+    return Error::SystemError;
+  }
+
+  MINIROS_DEBUG("MasterCache: saved \"%s\" (nodes=%zu)", path.string().c_str(), data.nodes.size());
+  return Error::Ok;
+}
+
+} // namespace master
+} // namespace miniros

--- a/src/roscore/master_cache.h
+++ b/src/roscore/master_cache.h
@@ -5,6 +5,7 @@
 #ifndef MINIROS_MASTER_CACHE_H
 #define MINIROS_MASTER_CACHE_H
 
+#include <atomic>
 #include <filesystem>
 #include <memory>
 #include <mutex>
@@ -110,7 +111,9 @@ private:
   MasterHandler* handler_ = nullptr;
 
   bool enabled_ = false;
-  bool dirty_ = false;
+  /// Written from RPC/callback threads via markDirty(); read/cleared on the
+  /// master update thread in saveIfNeeded(). Must be atomic for TSan/correctness.
+  std::atomic<bool> dirty_{false};
   bool restoring_ = false;
   bool loaded_ = false;
   SteadyTime restoreDeadline_;

--- a/src/roscore/master_cache.h
+++ b/src/roscore/master_cache.h
@@ -95,10 +95,14 @@ private:
   };
 
   static Error loadFile(const std::filesystem::path& path, MasterCacheData& out);
-  static Error saveFile(const std::filesystem::path& path, const MasterCacheData& data);
+  /// Atomically write via `path.tmp` + fsync + rename. Safe against power loss mid-write
+  /// when the filesystem honors POSIX rename semantics; reports disk-full / read-only.
+  static Error saveFile(const std::filesystem::path& path, const MasterCacheData& data,
+                        std::string* detail = nullptr);
 
   MasterCacheData collect(int port, const std::string& guid) const;
   void saveIfNeeded(int port, const std::string& guid);
+  void noteSaveResult(Error err, const std::string& detail);
   void processRestore();
   void finalizeRestore();
   void queueTopicList(const std::string& nodeName, const std::string& nodeApi,
@@ -119,6 +123,11 @@ private:
   SteadyTime restoreDeadline_;
   std::filesystem::path path_;
   MasterCacheData data_;
+
+  /// Persist-failure tracking (main / update thread only).
+  int saveFailCount_ = 0;
+  SteadyTime lastSaveErrorLog_;
+  std::string lastSaveError_;
 
   mutable std::mutex restoreMutex_;
   std::vector<PendingTopicRestore> pendingTopicRestores_;

--- a/src/roscore/master_cache.h
+++ b/src/roscore/master_cache.h
@@ -1,0 +1,127 @@
+//
+// Persistent state for miniroscore across restarts.
+//
+
+#ifndef MINIROS_MASTER_CACHE_H
+#define MINIROS_MASTER_CACHE_H
+
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "miniros/errors.h"
+#include "miniros/rostime.h"
+#include "miniros/xmlrpcpp/XmlRpcValue.h"
+
+namespace miniros {
+namespace master {
+
+class RegistrationManager;
+class MasterHandler;
+class NodeRef;
+
+/// One service advertisement known to master at the time of the snapshot.
+struct CachedService {
+  std::string name;
+  std::string service_api;
+};
+
+/// One registered node identity. Topic registrations are re-queried from the
+/// node on restore; services are restored from this snapshot because the ROS
+/// Slave API has no getServices method.
+struct CachedNode {
+  std::string name;
+  std::string api;
+  int pid = 0;
+  /// NodeRef::State name at the time of the snapshot (see State::toString).
+  std::string state;
+  std::vector<CachedService> services;
+};
+
+struct MasterCacheData {
+  std::string guid;
+  int port = 0;
+  std::vector<CachedNode> nodes;
+};
+
+/// Owns on-disk master state (cache.<port> in cwd) and the async restore session.
+class MasterCache {
+public:
+  using RpcValue = XmlRpc::XmlRpcValue;
+
+  MasterCache() = default;
+
+  /// Wire graph dependencies used during restore / snapshot.
+  void bind(RegistrationManager* regs, MasterHandler* handler);
+
+  void setEnabled(bool enabled);
+  bool enabled() const { return enabled_; }
+
+  /// Mark graph dirty so the next idle update() flushes to disk.
+  void markDirty();
+
+  /// Read cache.<port> once into memory. Safe to call before RPC bind.
+  Error load(int port);
+
+  /// GUID from the last successful load() (empty if none).
+  const std::string& guid() const { return data_.guid; }
+
+  /// Snapshot loaded by load(); used by beginRestore().
+  const MasterCacheData& data() const { return data_; }
+
+  /// Register cached nodes from the already-loaded snapshot and start restore.
+  /// @param port - bound server port (updates path for later saves if it differs).
+  /// @param runtimeGuid - GUID of this master instance (/run_id).
+  void beginRestore(int port, const std::string& runtimeGuid);
+
+  /// Drive restore progress and flush dirty state when idle.
+  void update(int port, const std::string& guid);
+
+  /// Write cache immediately (e.g. on shutdown), unless disabled or mid-restore.
+  void flush(int port, const std::string& guid);
+
+  static std::filesystem::path pathForPort(const std::filesystem::path& dir, int port);
+
+private:
+  struct PendingTopicRestore {
+    std::string nodeName;
+    std::string nodeApi;
+    bool publications = false;
+    int code = 0;
+    RpcValue data;
+  };
+
+  static Error loadFile(const std::filesystem::path& path, MasterCacheData& out);
+  static Error saveFile(const std::filesystem::path& path, const MasterCacheData& data);
+
+  MasterCacheData collect(int port, const std::string& guid) const;
+  void saveIfNeeded(int port, const std::string& guid);
+  void processRestore();
+  void finalizeRestore();
+  void queueTopicList(const std::string& nodeName, const std::string& nodeApi,
+    bool publications, int code, const RpcValue& data);
+  void applyTopicList(const std::string& nodeName, const std::string& nodeApi,
+    bool publications, int code, const RpcValue& data);
+  void restoreServices(const std::shared_ptr<NodeRef>& node);
+
+  RegistrationManager* regs_ = nullptr;
+  MasterHandler* handler_ = nullptr;
+
+  bool enabled_ = false;
+  bool dirty_ = false;
+  bool restoring_ = false;
+  bool loaded_ = false;
+  SteadyTime restoreDeadline_;
+  std::filesystem::path path_;
+  MasterCacheData data_;
+
+  mutable std::mutex restoreMutex_;
+  std::vector<PendingTopicRestore> pendingTopicRestores_;
+};
+
+} // namespace master
+} // namespace miniros
+
+#endif // MINIROS_MASTER_CACHE_H

--- a/src/roscore/master_internal.h
+++ b/src/roscore/master_internal.h
@@ -1,7 +1,3 @@
-//
-// Created by dkargin on 8/19/25.
-//
-
 #ifndef MINIROS_MASTER_INTERNAL_H
 #define MINIROS_MASTER_INTERNAL_H
 
@@ -13,8 +9,10 @@
 #include "parameter_storage.h"
 #include "master_handler.h"
 #include "discovery.h"
+#include "master_cache.h"
 
 #include "miniros/steady_timer.h"
+#include "miniros/rostime.h"
 
 namespace miniros {
 namespace master {
@@ -35,6 +33,9 @@ struct Master::Internal {
 
   MasterHandler handler;
   ParameterStorage parameterStorage;
+
+  /// Persistent GUID/node cache and async restore session.
+  MasterCache cache;
 
   /// Endpoint for accessing "GET /".
   std::shared_ptr<MasterRootEndpoint> httpRootEndpoint;

--- a/src/roscore/miniroscore.cpp
+++ b/src/roscore/miniroscore.cpp
@@ -78,6 +78,8 @@ protected:
 };
 
 int main(int argc, const char ** argv) {
+  // Install early so a crash during option parsing / init still dumps a stack.
+  handleCrashes();
   std::signal(SIGINT, systemSignalHandler);
 
   SteadyTime timeStart = SteadyTime::now();

--- a/src/roscore/miniroscore.cpp
+++ b/src/roscore/miniroscore.cpp
@@ -90,6 +90,7 @@ int main(int argc, const char ** argv) {
     ("xmlrpc_log", po::value<int>()->default_value(1), "Verbosity level of XmlRpc logging")
     ("rosout", po::value<bool>()->default_value(true), "Enable rosout log aggregator")
     ("dir", po::value<std::string>(), "Path to working directory")
+    ("no-cache", "Disable persistent state cache (cache.<port> in cwd)")
     ("resolve", po::value<bool>()->default_value(false), "Resolve node IP address")
     ("dump_parameters", po::value<bool>()->default_value(false), "Dump all ROSParam values on every update")
     ("pidfile", po::value<std::string>(), "Path to a PID file")
@@ -128,13 +129,14 @@ int main(int argc, const char ** argv) {
     resolve = vm["resolve"].as<bool>();
   }
 
+  std::string workingDir;
   if (vm.count("dir")) {
-    std::string wd = vm["dir"].as<std::string>();
+    workingDir = vm["dir"].as<std::string>();
 
-    if (!makeDirectory(wd))
+    if (!makeDirectory(workingDir))
       return EXIT_FAILURE;
 
-    if (!changeCurrentDirectory(wd))
+    if (!changeCurrentDirectory(workingDir))
       return EXIT_FAILURE;
   }
 
@@ -172,6 +174,8 @@ int main(int argc, const char ** argv) {
   master.setResolveNodeIP(resolve);
   master.setDumpParameters(dumpParameters);
   master.setNodeCheckPeriod(vm["node_check_period"].as<double>());
+  // Cache files (cache.<port>) are written to the current working directory.
+  master.setCacheEnabled(!vm.count("no-cache"));
 
   PidFile pidFile;
   if (vm.count("pidfile")) {

--- a/src/roscore/node_ref.cpp
+++ b/src/roscore/node_ref.cpp
@@ -10,6 +10,9 @@
 
 #include <cassert>
 #include <console.h>
+#include <cstring>
+#include <utility>
+#include <vector>
 
 namespace miniros {
 namespace master {
@@ -25,12 +28,31 @@ const char* NodeRef::State::toString() const
       return "Connected";
     case Verified:
       return "Verified";
+    case Restoring:
+      return "Restoring";
+    case Recovering:
+      return "Recovering";
     case ShuttingDown:
       return "ShuttingDown";
     case Dead:
       return "Dead";
   }
   return "Unknown";
+}
+
+bool NodeRef::State::fromString(const char* name)
+{
+  if (!name)
+    return false;
+  if (std::strcmp(name, "Initial") == 0) { value_ = Initial; return true; }
+  if (std::strcmp(name, "Connecting") == 0) { value_ = Connecting; return true; }
+  if (std::strcmp(name, "Connected") == 0) { value_ = Connected; return true; }
+  if (std::strcmp(name, "Verified") == 0) { value_ = Verified; return true; }
+  if (std::strcmp(name, "Restoring") == 0) { value_ = Restoring; return true; }
+  if (std::strcmp(name, "Recovering") == 0) { value_ = Recovering; return true; }
+  if (std::strcmp(name, "ShuttingDown") == 0) { value_ = ShuttingDown; return true; }
+  if (std::strcmp(name, "Dead") == 0) { value_ = Dead; return true; }
+  return false;
 }
 
 NodeRef::NodeRef(const std::string& _id, const std::string& _api)
@@ -248,7 +270,9 @@ std::shared_ptr<http::HttpClient> NodeRef::makeClient(PollSet* ps)
       std::string callerId;
       {
         std::unique_lock<std::mutex> lock(node->m_guard);
-        node->updateState(State::Connected, lock);
+        // Keep Restoring through TCP connect; getPid advances it to Recovering.
+        if (node->m_state != State::Restoring)
+          node->updateState(State::Connected, lock);
         callerId = node->m_callerId;
       }
       // Verify remote nodes after (re)connect; in-process nodes skip getPid.
@@ -309,7 +333,9 @@ Error NodeRef::activateConnection(const std::string& callerId, PollSet* ps)
     m_client = client;
 
     std::unique_lock lock(m_guard);
-    updateState(State::Connecting, lock);
+    // Restoring nodes stay Restoring until getPid; ordinary nodes go Connecting.
+    if (m_state != State::Restoring)
+      updateState(State::Connecting, lock);
   }
 
   // getPid is sent from the connect handler once the socket is up.
@@ -359,7 +385,8 @@ void NodeRef::handleDisconnect(const std::weak_ptr<http::HttpClient>& wclient, E
     MINIROS_INFO("%s - disconnected at state %s err=%s. Initiating reconnect (attempt %d)",
                  debugName().c_str(), m_state.toString(), disconnectError.toString(),
                  client->getReconnectAttempts());
-    updateState(State::Connecting, lock);
+    if (m_state != State::Restoring && m_state != State::Recovering)
+      updateState(State::Connecting, lock);
   } else {
     MINIROS_INFO("%s - disconnected at state %s. Failed to initiate reconnect: %s",
                  debugName().c_str(), m_state.toString(), err.toString());
@@ -374,6 +401,8 @@ void NodeRef::deactivateConnectionUnsafe(Lock& /*lock*/, ClientLock& /*clientLoc
   m_client.reset();
   m_reqGetPid.reset();
   m_reqShutdown.reset();
+  m_reqGetPublications.reset();
+  m_reqGetSubscriptions.reset();
   m_activeRequests.clear();
   m_pid = 0;
 }
@@ -545,12 +574,116 @@ void NodeRef::responseGetPid(int code, const std::string& msg, const RpcValue& d
     std::unique_lock lock(m_guard);
     m_pid = data.as<int>();
     MINIROS_INFO("%s::responseGetPid() pid=%d", debugName().c_str(), m_pid);
-    if (m_state == State::Connecting || m_state == State::Connected)
+    if (m_state == State::Restoring)
+      updateState(State::Recovering, lock);
+    else if (m_state == State::Connecting || m_state == State::Connected)
       updateState(State::Verified, lock);
   } else {
     MINIROS_ERROR("%s::responseGetPid unexpected response code=%d data=%s msg=%s",
                   debugName().c_str(), code, data.toJsonStr().c_str(), msg.c_str());
   }
+}
+
+Error NodeRef::sendGetPublications(const std::string& callerId,
+  std::function<void(int, const std::string&, const RpcValue&)> onComplete)
+{
+  if (!needRequests())
+    return Error::Ok;
+
+  auto client = getClient();
+  if (!client) {
+    MINIROS_ERROR("%s::sendGetPublications: No client available", debugName().c_str());
+    return Error::NotConnected;
+  }
+
+  std::shared_ptr<http::XmlRpcRequest> req;
+  {
+    std::unique_lock lock(m_guard);
+    if (!callerId.empty())
+      m_callerId = callerId;
+
+    if (!m_reqGetPublications) {
+      m_reqGetPublications = http::makeRequest(m_apiUrl.path, "getPublications");
+    } else {
+      auto s = m_reqGetPublications->state();
+      if (s != http::HttpRequest::State::Idle && s != http::HttpRequest::State::Done)
+        return Error::Ok;
+      m_reqGetPublications->resetResponse();
+      m_reqGetPublications->updateState(http::HttpRequest::State::Idle);
+    }
+
+    m_reqGetPublications->setParams(m_callerId);
+    m_reqGetPublications->generateRequestBody();
+    m_reqGetPublications->onComplete = std::move(onComplete);
+    std::weak_ptr<NodeRef> wnode = shared_from_this();
+    m_reqGetPublications->setFailureCallback([wnode]() {
+      if (auto node = wnode.lock()) {
+        std::shared_ptr<http::XmlRpcRequest> r;
+        {
+          std::unique_lock lock(node->m_guard);
+          r = node->m_reqGetPublications;
+        }
+        if (r)
+          node->m_activeRequests.erase(r);
+      }
+    });
+    req = m_reqGetPublications;
+  }
+
+  MINIROS_INFO("%s::sendGetPublications()", debugName().c_str());
+  m_activeRequests.insert(req);
+  return client->enqueueRequest(req);
+}
+
+Error NodeRef::sendGetSubscriptions(const std::string& callerId,
+  std::function<void(int, const std::string&, const RpcValue&)> onComplete)
+{
+  if (!needRequests())
+    return Error::Ok;
+
+  auto client = getClient();
+  if (!client) {
+    MINIROS_ERROR("%s::sendGetSubscriptions: No client available", debugName().c_str());
+    return Error::NotConnected;
+  }
+
+  std::shared_ptr<http::XmlRpcRequest> req;
+  {
+    std::unique_lock lock(m_guard);
+    if (!callerId.empty())
+      m_callerId = callerId;
+
+    if (!m_reqGetSubscriptions) {
+      m_reqGetSubscriptions = http::makeRequest(m_apiUrl.path, "getSubscriptions");
+    } else {
+      auto s = m_reqGetSubscriptions->state();
+      if (s != http::HttpRequest::State::Idle && s != http::HttpRequest::State::Done)
+        return Error::Ok;
+      m_reqGetSubscriptions->resetResponse();
+      m_reqGetSubscriptions->updateState(http::HttpRequest::State::Idle);
+    }
+
+    m_reqGetSubscriptions->setParams(m_callerId);
+    m_reqGetSubscriptions->generateRequestBody();
+    m_reqGetSubscriptions->onComplete = std::move(onComplete);
+    std::weak_ptr<NodeRef> wnode = shared_from_this();
+    m_reqGetSubscriptions->setFailureCallback([wnode]() {
+      if (auto node = wnode.lock()) {
+        std::shared_ptr<http::XmlRpcRequest> r;
+        {
+          std::unique_lock lock(node->m_guard);
+          r = node->m_reqGetSubscriptions;
+        }
+        if (r)
+          node->m_activeRequests.erase(r);
+      }
+    });
+    req = m_reqGetSubscriptions;
+  }
+
+  MINIROS_INFO("%s::sendGetSubscriptions()", debugName().c_str());
+  m_activeRequests.insert(req);
+  return client->enqueueRequest(req);
 }
 
 size_t NodeRef::getQueuedRequests() const
@@ -567,6 +700,54 @@ int NodeRef::pid() const
   return m_pid;
 }
 
+void NodeRef::beginRestore(std::vector<std::pair<std::string, std::string>> services)
+{
+  std::unique_lock lock(m_guard);
+  m_pendingRestoreServices = std::move(services);
+  m_restoreQueriesLeft = 0;
+  updateState(State::Restoring, lock);
+}
+
+bool NodeRef::isRestoreInProgress() const
+{
+  std::unique_lock lock(m_guard);
+  return m_state.isRestoreInProgress();
+}
+
+int NodeRef::restoreQueriesLeft() const
+{
+  std::unique_lock lock(m_guard);
+  return m_restoreQueriesLeft;
+}
+
+void NodeRef::beginTopicRecovery(int queryCount)
+{
+  std::unique_lock lock(m_guard);
+  if (m_state != State::Recovering)
+    updateState(State::Recovering, lock);
+  m_restoreQueriesLeft = queryCount;
+}
+
+bool NodeRef::notifyRestoreQueryDone()
+{
+  std::unique_lock lock(m_guard);
+  if (m_restoreQueriesLeft > 0)
+    --m_restoreQueriesLeft;
+  if (m_restoreQueriesLeft > 0)
+    return false;
+  if (m_state == State::Recovering)
+    updateState(State::Verified, lock);
+  return true;
+}
+
+std::vector<std::pair<std::string, std::string>> NodeRef::takePendingRestoreServices()
+{
+  std::unique_lock lock(m_guard);
+  std::vector<std::pair<std::string, std::string>> out;
+  out.swap(m_pendingRestoreServices);
+  return out;
+}
+
 void NodeRef::markDead()
 {
   // Lock order matches activateConnection: m_clientGuard then m_guard.
@@ -576,6 +757,8 @@ void NodeRef::markDead()
     return;
   MINIROS_WARN("%s::markDead()", debugName().c_str());
   deactivateConnectionUnsafe(lock, clientLock);
+  m_pendingRestoreServices.clear();
+  m_restoreQueriesLeft = 0;
   updateState(State::Dead, lock);
 }
 

--- a/src/roscore/node_ref.h
+++ b/src/roscore/node_ref.h
@@ -9,6 +9,9 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <functional>
+#include <utility>
+#include <vector>
 
 #include "miniros/macros.h"
 #include "miniros/network/url.h"
@@ -60,6 +63,10 @@ public:
       Connected,
       /// Master has managed to contact node by "getPid" request.
       Verified,
+      /// Loaded from master's disk cache; reconnecting and waiting for getPid.
+      Restoring,
+      /// getPid succeeded after cache restore; Slave API topic queries in flight.
+      Recovering,
       /// Sent shutdown request.
       ShuttingDown,
       /// Node is considered dead. It can be caused either by shutdown request
@@ -77,6 +84,16 @@ public:
     }
 
     const char* toString() const;
+
+    /// Parse state name produced by toString(). Returns false on unknown values.
+    bool fromString(const char* name);
+    bool fromString(const std::string& name) { return fromString(name.c_str()); }
+
+    /// True while master is re-attaching this node from a cache snapshot.
+    bool isRestoreInProgress() const
+    {
+      return value_ == Restoring || value_ == Recovering;
+    }
 
   protected:
     State_t value_ = State::Initial;
@@ -188,6 +205,14 @@ public:
   /// Response method for GetPid request.
   void responseGetPid(int code, const std::string& msg, const RpcValue& data);
 
+  /// Query Slave API getPublications. Callback receives ROS (code, msg, data).
+  Error sendGetPublications(const std::string& callerId,
+    std::function<void(int, const std::string&, const RpcValue&)> onComplete);
+
+  /// Query Slave API getSubscriptions. Callback receives ROS (code, msg, data).
+  Error sendGetSubscriptions(const std::string& callerId,
+    std::function<void(int, const std::string&, const RpcValue&)> onComplete);
+
   /// Notify client about updated publishers.
   /// @param callerId - name of requester node.
   /// @param topic - name of updated topic
@@ -206,6 +231,27 @@ public:
   /// Last known PID of the node process (0 if unknown).
   /// Obtained via Slave API getPid; not used for OS-level signals.
   int pid() const;
+
+  /// Mark node as loaded from disk cache (state → Restoring).
+  /// @param services - service name + rosrpc URI pairs to re-register after getPid.
+  void beginRestore(std::vector<std::pair<std::string, std::string>> services);
+
+  /// True while state is Restoring or Recovering.
+  bool isRestoreInProgress() const;
+
+  /// Number of in-flight getPublications/getSubscriptions during Recovering.
+  int restoreQueriesLeft() const;
+
+  /// Start topic recovery queries (Restoring is already past getPid → Recovering).
+  /// Sets restoreQueriesLeft to @p count.
+  void beginTopicRecovery(int queryCount);
+
+  /// Decrement restore query counter; when it hits 0, state → Verified.
+  /// @returns true when recovery for this node has finished.
+  bool notifyRestoreQueryDone();
+
+  /// Take and clear cached service advertisements from the restore snapshot.
+  std::vector<std::pair<std::string, std::string>> takePendingRestoreServices();
 
   /// Mark node as dead and tear down its HTTP client.
   void markDead();
@@ -264,10 +310,22 @@ protected:
   /// Request to get PID of a process.
   std::shared_ptr<http::XmlRpcRequest> m_reqGetPid GUARDED_BY(m_guard);
 
+  /// Request to list publications (restore path).
+  std::shared_ptr<http::XmlRpcRequest> m_reqGetPublications GUARDED_BY(m_guard);
+
+  /// Request to list subscriptions (restore path).
+  std::shared_ptr<http::XmlRpcRequest> m_reqGetSubscriptions GUARDED_BY(m_guard);
+
   State m_state GUARDED_BY(m_guard) = State::Initial;
 
   /// Collection of active requests.
   SafeSet<std::shared_ptr<http::HttpRequest>> m_activeRequests;
+
+  /// Service name → rosrpc URI, kept until Recovering restores them.
+  std::vector<std::pair<std::string, std::string>> m_pendingRestoreServices GUARDED_BY(m_guard);
+
+  /// In-flight getPublications / getSubscriptions during Recovering.
+  int m_restoreQueriesLeft GUARDED_BY(m_guard) = 0;
 };
 
 using NodeRefPtr = std::shared_ptr<NodeRef>;

--- a/src/roscore/registration_manager.cpp
+++ b/src/roscore/registration_manager.cpp
@@ -96,7 +96,7 @@ std::shared_ptr<NodeRef> RegistrationManager::_register(Registrations& r, const 
 void RegistrationManager::dropRegistrations(const NodeRef& node)
 {
   std::string name = node.id();
-  MINIROS_INFO("Unregistering everything from superseded node \"%s\" at %s", name.c_str(), node.getApi().c_str());
+  MINIROS_INFO("Unregistering everything from node \"%s\" at %s", name.c_str(), node.getApi().c_str());
   publishers.unregisterAll(name);
   subscribers.unregisterAll(name);
   services.unregisterAll(name);
@@ -208,6 +208,19 @@ RegistrationManager::registerNodeApi(const std::string& nodeName, const std::str
       return report;
     }
 
+    // A surviving node may re-advertise while MasterCache is still restoring it,
+    // often with a differently spelled URI (hostname vs IP). Superseding would
+    // abort restore (drop getPublications) and drop the only live peer.
+    if (report.node->isRestoreInProgress()) {
+      MINIROS_WARN_NAMED("reg",
+        "Keeping restoring node \"%s\" (cached api=%s, live api=%s)",
+        nodeName.c_str(), report.node->getApi().c_str(), nodeApi.c_str());
+      if (flags & NodeRef::NODE_LOCAL)
+        report.node->setLocal();
+      report.node->setNodeFlags(flags);
+      return report;
+    }
+
     // TODO: Need to check PID of the new node and verify that it has changed.
     // TODO: Need to check some alternative IP addresses to verify this node is really new.
     NodeRefPtr prevNode;
@@ -274,6 +287,11 @@ std::vector<NodeRefPtr> RegistrationManager::checkNodesForRemoval()
 
     for (auto& [key, node]: m_nodes) {
       assert(node);
+      // Cache-restored nodes start with no topic/service registrations until
+      // getPublications / service restore finishes. Do not treat that empty
+      // window as "gone" or restore never completes.
+      if (node->isRestoreInProgress())
+        continue;
       if (node->getState() == NodeRef::State::Dead || node->isEmpty()) {
         graveyard.push_back(node);
       }

--- a/src/transport/connection.cpp
+++ b/src/transport/connection.cpp
@@ -340,13 +340,10 @@ void Connection::drop(DropReason reason)
 {
   MINIROS_DEBUG("Connection::drop(%u)", reason);
   bool did_drop = false;
-  {
-    if (!dropped_)
-    {
-      dropped_ = true;
-      did_drop = true;
-    }
-  }
+  // dropped_ is atomic; set before clearing buffers so concurrent I/O paths
+  // observe the drop and bail out once they take their path mutex.
+  if (!dropped_.exchange(true))
+    did_drop = true;
 
   if (did_drop)
   {
@@ -375,6 +372,10 @@ void Connection::drop(DropReason reason)
       has_read_callback_ = 0;
     }
     {
+      // writeTransport() holds write_mutex_ while reading write_buffer_/sizes.
+      // Take the same lock (then write_callback_mutex_) so shutdown cannot clear
+      // those fields under only write_callback_mutex_ while PollManager writes.
+      std::scoped_lock<std::recursive_mutex> wlock(write_mutex_);
       std::scoped_lock<std::mutex> lock(write_callback_mutex_);
       write_callback_ = {};
       write_buffer_ = {};

--- a/test/launch_test.sh
+++ b/test/launch_test.sh
@@ -208,15 +208,23 @@ dump_master_diagnostics() {
     echo "master process not running (pid='$master_pid')" | tee -a "$outdir/master-stacks.txt" >&2
   fi
 
-  for f in "$logdir/rosout.log" "$bindir/rosout.log" "$logdir/miniroscore.console.log" \
-           "$logdir/miniroscore.crash" "$bindir/miniroscore.crash" \
-           "$bindir/late-master-logs/miniroscore.crash" \
-           "$bindir/late-master-logs/miniroscore.console.log"; do
-    if [[ -f "$f" ]]; then
-      cp -f "$f" "$outdir/" 2>/dev/null || true
-      echo "copied $f" >&2
+  # Copy with unique basenames — late-master logs share names with the shared
+  # master console/crash files and must not overwrite them in $outdir.
+  copy_diag() {
+    local src=$1
+    local dest_name=$2
+    if [[ -f "$src" ]]; then
+      cp -f "$src" "$outdir/$dest_name" 2>/dev/null || true
+      echo "copied $src -> $dest_name" >&2
     fi
-  done
+  }
+  copy_diag "$logdir/rosout.log" "rosout.log"
+  copy_diag "$bindir/rosout.log" "bin-rosout.log"
+  copy_diag "$logdir/miniroscore.console.log" "miniroscore.console.log"
+  copy_diag "$logdir/miniroscore.crash" "miniroscore.crash"
+  copy_diag "$bindir/miniroscore.crash" "bin-miniroscore.crash"
+  copy_diag "$bindir/late-master-logs/miniroscore.crash" "late-master-miniroscore.crash"
+  copy_diag "$bindir/late-master-logs/miniroscore.console.log" "late-master-miniroscore.console.log"
 
   # Core dumps (workflow sets core_pattern to $PWD/cores/...).
   local core_copied=0

--- a/test/launch_test.sh
+++ b/test/launch_test.sh
@@ -131,6 +131,50 @@ dump_process_tree() {
   done
 }
 
+# Echo a file (or interesting excerpts) to stderr so GitHub Actions job logs
+# show the master crash stack without downloading artifacts.
+print_master_log_excerpt() {
+  local label=$1
+  local file=$2
+  local max_lines=${3:-200}
+
+  if [[ ! -f "$file" ]]; then
+    echo "=== $label: missing ($file) ===" >&2
+    return
+  fi
+  local sz
+  sz=$(wc -c <"$file" | tr -d ' ')
+  if [[ "$sz" == "0" ]]; then
+    echo "=== $label: empty ($file) ===" >&2
+    return
+  fi
+
+  echo "=== $label ($file, ${sz} bytes) ===" >&2
+  # Crash dumps and gdb bt files are short — print whole file.
+  if [[ "$label" == *crash* || "$label" == *backtrace* || "$label" == *.bt* ]]; then
+    cat "$file" >&2 || true
+    echo "=== end $label ===" >&2
+    return
+  fi
+
+  # Console / rosout can be huge; prefer sanitizer/crash markers, else tail.
+  local matched=0
+  if command -v rg >/dev/null 2>&1; then
+    if rg -n "fatalSignalHandler|ThreadSanitizer|AddressSanitizer|SUMMARY:|DEADLYSIGNAL|ABORTING|SIGSEGV|signal=" "$file" >&2; then
+      matched=1
+    fi
+  elif grep -nE 'fatalSignalHandler|ThreadSanitizer|AddressSanitizer|SUMMARY:|DEADLYSIGNAL|ABORTING|SIGSEGV|signal=' "$file" >&2; then
+    matched=1
+  fi
+  if (( matched )); then
+    echo "=== end $label (matched crash/sanitizer lines) ===" >&2
+  else
+    echo "(no sanitizer/crash markers; last ${max_lines} lines)" >&2
+    tail -n "$max_lines" "$file" >&2 || true
+    echo "=== end $label ===" >&2
+  fi
+}
+
 dump_master_diagnostics() {
   local bindir=$1
   local reason=$2
@@ -164,18 +208,51 @@ dump_master_diagnostics() {
     echo "master process not running (pid='$master_pid')" | tee -a "$outdir/master-stacks.txt" >&2
   fi
 
-  for f in "$logdir/rosout.log" "$bindir/rosout.log" "$logdir/miniroscore.console.log"; do
+  for f in "$logdir/rosout.log" "$bindir/rosout.log" "$logdir/miniroscore.console.log" \
+           "$logdir/miniroscore.crash" "$bindir/miniroscore.crash" \
+           "$bindir/late-master-logs/miniroscore.crash" \
+           "$bindir/late-master-logs/miniroscore.console.log"; do
     if [[ -f "$f" ]]; then
       cp -f "$f" "$outdir/" 2>/dev/null || true
       echo "copied $f" >&2
     fi
   done
 
+  # Core dumps (workflow sets core_pattern to $PWD/cores/...).
+  local core_copied=0
+  for f in cores/corefile-miniroscore-* "$bindir"/core* core*; do
+    [[ -f "$f" ]] || continue
+    cp -f "$f" "$outdir/" 2>/dev/null || true
+    echo "copied core $f" >&2
+    core_copied=1
+    # Best-effort offline backtrace if the process is already gone.
+    if command -v gdb >/dev/null 2>&1 && [[ -x "$bindir/miniroscore" ]]; then
+      local btfile="$outdir/$(basename "$f").bt.txt"
+      gdb -batch -ex "set pagination off" -ex "bt" -ex "thread apply all bt" \
+        "$bindir/miniroscore" "$f" >"$btfile" 2>&1 || true
+    fi
+  done
+  if (( core_copied == 0 )); then
+    echo "no core dumps found for miniroscore" >&2
+  fi
+
   local b
   for b in "$logdir"/rosout.log.[0-9]*; do
     [[ -f "$b" ]] || continue
     cp -f "$b" "$outdir/" 2>/dev/null || true
   done
+
+  # Surface stacks in the CI job log (ctest captures stderr).
+  print_master_log_excerpt "miniroscore.crash" "$outdir/miniroscore.crash"
+  print_master_log_excerpt "miniroscore.console.log" "$outdir/miniroscore.console.log" 120
+  local bt
+  for bt in "$outdir"/*.bt.txt; do
+    [[ -f "$bt" ]] || continue
+    print_master_log_excerpt "core backtrace $(basename "$bt")" "$bt"
+  done
+  if [[ -f "$outdir/master-stacks.txt" ]]; then
+    print_master_log_excerpt "live master stacks" "$outdir/master-stacks.txt"
+  fi
 
   ls -la "$outdir" >&2 || true
   echo "$outdir"

--- a/test/manage-master.cpp
+++ b/test/manage-master.cpp
@@ -100,11 +100,18 @@ int main(int argc, char** argv)
       std::string("--rosout=true"),
     };
 
+    // Always keep a console capture under the log dir so a crash still leaves
+    // stderr (and handleCrashes() output) in the CI artifact tree.
+    const std::string consoleLog = (logDir / "miniroscore.console.log").string();
+    const std::string crashLog = (logDir / "miniroscore.crash").string();
+    launcher.env("MINIROS_MASTER_CONSOLE_LOG", consoleLog.c_str());
+    launcher.env("MINIROS_CRASH_LOG", crashLog.c_str());
+    std::cout << "miniroscore console -> " << consoleLog << std::endl;
+    std::cout << "miniroscore crash log -> " << crashLog << std::endl;
+
     if (envTruthy("MINIROS_MASTER_DEBUG")) {
       args.emplace_back("--xmlrpc_log=4");
-      const std::string consoleLog = (logDir / "miniroscore.console.log").string();
-      launcher.env("MINIROS_MASTER_CONSOLE_LOG", consoleLog.c_str());
-      std::cout << "MINIROS_MASTER_DEBUG: console -> " << consoleLog << std::endl;
+      std::cout << "MINIROS_MASTER_DEBUG: xmlrpc_log=4" << std::endl;
     }
 
     // DETACHED: master survives after this process exits.

--- a/test/roscpp/advanced/check_master.cpp
+++ b/test/roscpp/advanced/check_master.cpp
@@ -41,6 +41,7 @@
 #include "miniros/ros.h"
 
 #include "miniros/master_link.h"
+#include "miniros/platform.h"
 
 #include <miniros/transport/rpc_manager.h>
 #include <miniros/transport/topic_manager.h>
@@ -48,20 +49,6 @@
 using namespace XmlRpc;
 
 bool g_should_exist = true;
-
-#ifdef _WIN32
-int setenv(const char *name, const char *value, int overwrite)
-{
-  if(!overwrite)
-  {
-    size_t envsize = 0;
-    const errno_t errcode = getenv_s(&envsize, NULL, 0, name);
-    if(errcode || envsize)
-      return errcode;
-  }
-  return _putenv_s(name, value);
-}
-#endif
 
 TEST(CheckMaster, checkMaster)
 {
@@ -86,7 +73,8 @@ int main(int argc, char** argv)
   if (args[1] == "no")
   {
     g_should_exist = false;
-    setenv("ROS_MASTER_URI", "http://invalid_host_name_blahahahahahahahahahahaha:11311", 1);
+    miniros::set_environment_variable(
+        "ROS_MASTER_URI", "http://invalid_host_name_blahahahahahahahahahahaha:11311");
     std::cout << getenv("ROS_MASTER_URI") << std::endl;
   }
 

--- a/test/roscpp/advanced/namespaces.cpp
+++ b/test/roscpp/advanced/namespaces.cpp
@@ -40,6 +40,7 @@
 #include <gtest/gtest.h>
 
 #include <miniros/ros.h>
+#include <miniros/platform.h>
 #include "master_fixture.h"
 #include "../../require_master.h"
 
@@ -91,11 +92,9 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
 
-#ifndef _WIN32
-  setenv("ROS_NAMESPACE", "ROS_NAMESPACE", 1);
-#else
-  _putenv_s("ROS_NAMESPACE", "ROS_NAMESPACE");
-#endif
+  if (!miniros::set_environment_variable("ROS_NAMESPACE", "ROS_NAMESPACE")) {
+    return EXIT_FAILURE;
+  }
 
   miniros::init(argc, argv, "NODE_NAME");
   miniros::test::requireMasterOrExit("advanced-namespaces");

--- a/test/roscpp/basic/CMakeLists.txt
+++ b/test/roscpp/basic/CMakeLists.txt
@@ -45,6 +45,18 @@ target_compile_definitions(${TEST_GROUP}-test_late_master PRIVATE
   MINIROS_TEST_BIN_DIR="${CMAKE_BINARY_DIR}/bin")
 add_dependencies(${TEST_GROUP}-test_late_master miniroscore ${TEST_GROUP}-test_late_master_node)
 
+# Master killed + restarted from cache; surviving publisher is rediscovered by a new subscriber.
+add_executable(${TEST_GROUP}-test_master_cache_pub test_master_cache_pub.cpp)
+target_link_libraries(${TEST_GROUP}-test_master_cache_pub roscxx)
+target_include_directories(${TEST_GROUP}-test_master_cache_pub PRIVATE ${MINIROS_GENERATED_INCLUDE_DIRS})
+set_target_properties(${TEST_GROUP}-test_master_cache_pub PROPERTIES FOLDER "Tests")
+
+miniros_add_test(${TEST_GROUP}-test_master_cache SOURCES test_master_cache.cpp)
+target_compile_definitions(${TEST_GROUP}-test_master_cache PRIVATE
+  MINIROS_TEST_BIN_DIR="${CMAKE_BINARY_DIR}/bin")
+target_include_directories(${TEST_GROUP}-test_master_cache PRIVATE ${MINIROS_GENERATED_INCLUDE_DIRS})
+add_dependencies(${TEST_GROUP}-test_master_cache miniroscore ${TEST_GROUP}-test_master_cache_pub)
+
 if(catkin_FOUND AND CATKIN_ENABLE_TESTING)
   message(STATUS "Trying to find rostest for more complex testing")
   find_package(rostest REQUIRED)

--- a/test/roscpp/basic/test_http.cpp
+++ b/test/roscpp/basic/test_http.cpp
@@ -658,8 +658,10 @@ TEST_F(HttpServerTest, PeerDisconnectFailsQueuedXmlRpcWithoutParse)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   ASSERT_TRUE(entered->load()) << "hanging endpoint never received a request";
+  ASSERT_EQ(requests[0]->state(), http::HttpRequest::State::ClientWaitResponse);
 
-  // Kill the peer while requests are still outstanding.
+  // Kill the peer while requests are still outstanding. HttpServer::stop() must
+  // FIN accepted sockets (not only the listen fd) so the client sees EOF.
   server_->stop();
   server_.reset();
 

--- a/test/roscpp/basic/test_http.cpp
+++ b/test/roscpp/basic/test_http.cpp
@@ -671,6 +671,10 @@ TEST_F(HttpServerTest, PeerDisconnectFailsQueuedXmlRpcWithoutParse)
         << req->state().toString();
   }
 
+  const auto waitFails = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (fails.load() < numRequests && std::chrono::steady_clock::now() < waitFails) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
   EXPECT_EQ(fails.load(), numRequests);
   EXPECT_EQ(client.getQueuedRequests(), 0u);
   EXPECT_EQ(invalidResponses.load(), 0)

--- a/test/roscpp/basic/test_http.cpp
+++ b/test/roscpp/basic/test_http.cpp
@@ -12,6 +12,7 @@
 
 #include "miniros/http/http_client.h"
 #include "miniros/http/http_request.h"
+#include "miniros/http/xmlrpc_request.h"
 #include "miniros/http/http_server.h"
 #include "miniros/http/http_tools.h"
 #include "miniros/http/http_endpoint.h"
@@ -582,6 +583,100 @@ TEST_F(HttpServerTest, MixedSyncAndAsyncEndpoints)
   // Verify handlers were called
   EXPECT_EQ(asyncHandler->getCallCount(), 1U);
   EXPECT_EQ(syncHandler->counter, 1);
+}
+
+// Blocks in the callback-queue thread so the TCP response is never written while
+// the client still has an in-flight (and possibly queued) request.
+class HangEndpointHandler : public http::EndpointHandler {
+public:
+  explicit HangEndpointHandler(std::shared_ptr<std::atomic<bool>> entered,
+                               std::shared_ptr<std::atomic<bool>> release)
+    : entered_(std::move(entered)), release_(std::move(release))
+  {}
+
+  Error handle(const network::ClientInfo&, std::shared_ptr<http::HttpRequest> request) override
+  {
+    if (entered_)
+      entered_->store(true);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+    while (release_ && !release_->load() && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    request->setResponseStatusOk();
+    request->setResponseBody("{}", "application/json");
+    return Error::Ok;
+  }
+
+private:
+  std::shared_ptr<std::atomic<bool>> entered_;
+  std::shared_ptr<std::atomic<bool>> release_;
+};
+
+TEST_F(HttpServerTest, PeerDisconnectFailsQueuedXmlRpcWithoutParse)
+{
+  // Regression: peer close with an in-flight request + queued follow-ups used to
+  // treat EOF as a successful empty HTTP body, so XmlRpcRequest::processResponse
+  // logged "no methodResponse" for every dropped request.
+  auto entered = std::make_shared<std::atomic<bool>>(false);
+  auto release = std::make_shared<std::atomic<bool>>(false);
+  auto hang = std::make_shared<HangEndpointHandler>(entered, release);
+  server_->registerEndpoint(
+    std::make_unique<http::SimpleFilter>(http::HttpMethod::Post, "/RPC2"),
+    hang, callback_queue_);
+
+  http::HttpClient client(&poll_manager_.getPollSet());
+  int port = getServerPort();
+  Error conErr = client.connect("127.0.0.1", port);
+  ASSERT_TRUE(conErr == Error::Ok || conErr == Error::Timeout);
+  ASSERT_EQ(client.waitConnected(WallDuration(connectionTimeoutSec)), Error::Ok);
+
+  std::atomic<int> fails{0};
+  std::atomic<int> completes{0};
+  std::atomic<int> invalidResponses{0};
+
+  const int numRequests = 3;
+  std::vector<std::shared_ptr<http::XmlRpcRequest>> requests;
+  requests.reserve(numRequests);
+  for (int i = 0; i < numRequests; ++i) {
+    auto req = http::makeRequest("/RPC2", "getPid");
+    req->setParams(std::string("/peer_disconnect_test"));
+    req->setRetry(0);
+    req->onCompleteRaw = [&](Error err, const XmlRpc::XmlRpcValue&, bool) {
+      completes.fetch_add(1);
+      if (err == Error::InvalidResponse)
+        invalidResponses.fetch_add(1);
+    };
+    req->setFailureCallback([&]() { fails.fetch_add(1); });
+    ASSERT_EQ(client.enqueueRequest(req), Error::Ok);
+    requests.push_back(req);
+  }
+
+  // Wait until the server has accepted the first request and is hanging before
+  // writing a response (so the client is in ReadResponse / has a queue).
+  const auto waitEntered = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!entered->load() && std::chrono::steady_clock::now() < waitEntered) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  ASSERT_TRUE(entered->load()) << "hanging endpoint never received a request";
+
+  // Kill the peer while requests are still outstanding.
+  server_->stop();
+  server_.reset();
+
+  for (auto& req : requests) {
+    EXPECT_EQ(req->waitForState(http::HttpRequest::State::Idle, WallDuration(5.0)), Error::Ok)
+        << "request should fail to Idle after peer disconnect, state="
+        << req->state().toString();
+  }
+
+  EXPECT_EQ(fails.load(), numRequests);
+  EXPECT_EQ(client.getQueuedRequests(), 0u);
+  EXPECT_EQ(invalidResponses.load(), 0)
+      << "EOF must not be parsed as an empty XML-RPC methodResponse";
+  EXPECT_EQ(completes.load(), 0)
+      << "processResponse should not run for transport-failed requests";
+
+  release->store(true);  // unblock hang handler if the callback thread is still in it
 }
 
 int main(int argc, char** argv)

--- a/test/roscpp/basic/test_late_master.cpp
+++ b/test/roscpp/basic/test_late_master.cpp
@@ -5,6 +5,8 @@
 
 #include <chrono>
 #include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -29,8 +31,67 @@ std::filesystem::path executable(const char* name)
   return binDir() / name;
 }
 
+std::filesystem::path lateMasterLogDir()
+{
+  return binDir() / "late-master-logs";
+}
+
+/// Print crash/console excerpts to stderr so they appear in the CI job log.
+void dumpLateMasterLogs(const char* reason)
+{
+  const auto logDir = lateMasterLogDir();
+  std::cerr << "=== LATE MASTER DIAGNOSTICS (" << reason << ") dir=" << logDir << " ===\n";
+
+  const auto printFile = [](const std::filesystem::path& path, bool whole_if_small) {
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(path, ec)) {
+      std::cerr << "=== missing " << path << " ===\n";
+      return;
+    }
+    const auto sz = std::filesystem::file_size(path, ec);
+    if (ec || sz == 0) {
+      std::cerr << "=== empty " << path << " ===\n";
+      return;
+    }
+    std::cerr << "=== " << path.filename().string() << " (" << sz << " bytes) ===\n";
+    std::ifstream in(path);
+    if (!in) {
+      std::cerr << "(failed to open)\n";
+      return;
+    }
+    // Crash files are short; console may include TSan stacks — print up to ~64KiB from the end.
+    constexpr std::uintmax_t kMax = 64 * 1024;
+    if (whole_if_small || sz <= kMax) {
+      std::cerr << in.rdbuf();
+    } else {
+      in.seekg(static_cast<std::streamoff>(sz - kMax));
+      std::string line;
+      std::getline(in, line); // discard partial first line
+      std::cerr << in.rdbuf();
+    }
+    std::cerr << "\n=== end " << path.filename().string() << " ===\n";
+  };
+
+  printFile(logDir / "miniroscore.crash", true);
+  printFile(logDir / "miniroscore.console.log", false);
+}
+
 miniros::Error startMaster(int port, miniros::Launcher& launcher)
 {
+  // Point crash/console dumps at the test bin dir so CI artifacts / job logs can
+  // show stacks if this private master dies (not the shared advanced-suite master).
+  const auto logDir = lateMasterLogDir();
+  std::error_code ec;
+  std::filesystem::create_directories(logDir, ec);
+  const auto crashLog = (logDir / "miniroscore.crash").string();
+  const auto consoleLog = (logDir / "miniroscore.console.log").string();
+  // Truncate previous run so failure dumps are not stale.
+  std::ofstream(crashLog, std::ios::trunc);
+  std::ofstream(consoleLog, std::ios::trunc);
+  launcher.env("MINIROS_MASTER_LOG_DIR", logDir.string().c_str())
+          .env("MINIROS_CRASH_LOG", crashLog.c_str())
+          .env("MINIROS_MASTER_CONSOLE_LOG", consoleLog.c_str());
+
   const std::vector<std::string> args = {
     "-p", std::to_string(port),
     "--rosout", "false",
@@ -54,6 +115,12 @@ class LateMasterTest : public ::testing::Test {
 protected:
   void TearDown() override
   {
+    if (HasFailure()) {
+      const bool masterAlive = master_.running();
+      std::cerr << "late_master TearDown: master_running=" << masterAlive
+                << " node_running=" << node_.running() << std::endl;
+      dumpLateMasterLogs(masterAlive ? "test-failed-master-still-up" : "test-failed-master-dead");
+    }
     node_.stopAndWait(miniros::WallDuration(5.0));
     master_.stopAndWait(miniros::WallDuration(5.0));
   }
@@ -83,12 +150,20 @@ TEST_F(LateMasterTest, NodeStartsBeforeMasterThenConnects)
   const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
   miniros::Error waitErr = miniros::Error::Timeout;
   while (std::chrono::steady_clock::now() < deadline) {
+    if (!master_.running()) {
+      dumpLateMasterLogs("master-exited-during-wait");
+      FAIL() << "miniroscore exited while waiting for node to connect on " << masterUri;
+    }
     waitErr = node_.waitReady(&ready, miniros::WallDuration(1.0));
     if (waitErr == miniros::Error::Ok)
       break;
     if (!node_.running()) {
+      dumpLateMasterLogs("node-exited-during-wait");
       FAIL() << "basic-test_late_master_node exited without notifying (still waiting for master connect)";
     }
+  }
+  if (waitErr != miniros::Error::Ok) {
+    dumpLateMasterLogs("node-never-connected");
   }
   ASSERT_EQ(waitErr, miniros::Error::Ok)
       << "Node should finish init/advertise once the master appears on " << masterUri;

--- a/test/roscpp/basic/test_launcher.cpp
+++ b/test/roscpp/basic/test_launcher.cpp
@@ -14,6 +14,7 @@
 
 #include "miniros/common.h"
 #include "miniros/launcher.h"
+#include "miniros/platform.h"
 
 #if !defined(WIN32)
 #include <unistd.h>
@@ -42,15 +43,9 @@ std::filesystem::path notifyChildPath()
 
 void clearNotifyEnv()
 {
-#if defined(WIN32)
-  _putenv("NOTIFY_SOCKET=");
-  _putenv("MINIROS_NOTIFY_HANDLE=");
-  _putenv("MINIROS_NOTIFY_FD=");
-#else
-  unsetenv("NOTIFY_SOCKET");
-  unsetenv("MINIROS_NOTIFY_FD");
-  unsetenv("MINIROS_NOTIFY_HANDLE");
-#endif
+  miniros::unset_environment_variable("NOTIFY_SOCKET");
+  miniros::unset_environment_variable("MINIROS_NOTIFY_HANDLE");
+  miniros::unset_environment_variable("MINIROS_NOTIFY_FD");
 }
 
 } // namespace
@@ -70,8 +65,8 @@ TEST(Notify, PipeDeliversPidAndPort)
 {
   int fds[2] = {-1, -1};
   ASSERT_EQ(pipe(fds), 0);
-  ASSERT_EQ(setenv("MINIROS_NOTIFY_FD", std::to_string(fds[1]).c_str(), 1), 0);
-  unsetenv("NOTIFY_SOCKET");
+  ASSERT_TRUE(miniros::set_environment_variable("MINIROS_NOTIFY_FD", std::to_string(fds[1]).c_str()));
+  miniros::unset_environment_variable("NOTIFY_SOCKET");
 
   miniros::NodeNotifyInfo info;
   info.rpcPort = 4242;
@@ -82,7 +77,7 @@ TEST(Notify, PipeDeliversPidAndPort)
   const ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
   close(fds[0]);
   close(fds[1]);
-  unsetenv("MINIROS_NOTIFY_FD");
+  miniros::unset_environment_variable("MINIROS_NOTIFY_FD");
 
   ASSERT_GT(n, 0);
   const std::string msg(buf, static_cast<size_t>(n));

--- a/test/roscpp/basic/test_master_cache.cpp
+++ b/test/roscpp/basic/test_master_cache.cpp
@@ -1,0 +1,233 @@
+//
+// Master cache restore: publisher survives a master restart; a later subscriber
+// still discovers it via the restored graph.
+//
+// 1. Start miniroscore with --dir (isolated cache.<port>).
+// 2. Start a latching publisher; wait until cache is on disk.
+// 3. Stop master (SIGINT → flush); publisher keeps running.
+// 4. Restart master from the same cache dir/port.
+// 5. Subscribe and receive the latched message from the surviving publisher.
+//
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "miniros/launcher.h"
+#include "miniros/ros.h"
+#include "std_msgs/String.hxx"
+
+namespace {
+
+constexpr int kMasterPort = 11721;
+constexpr const char* kTopic = "cache_test_chatter";
+constexpr const char* kPayload = "hello-from-cached-publisher";
+constexpr const char* kPubNode = "cache_test_pub";
+
+std::filesystem::path binDir()
+{
+#ifdef MINIROS_TEST_BIN_DIR
+  return std::filesystem::path(MINIROS_TEST_BIN_DIR);
+#else
+  return std::filesystem::current_path();
+#endif
+}
+
+std::filesystem::path executable(const char* name)
+{
+  return binDir() / name;
+}
+
+std::filesystem::path cacheDir()
+{
+  return binDir() / "master-cache-test";
+}
+
+std::filesystem::path cacheFile(int port)
+{
+  return cacheDir() / ("cache." + std::to_string(port));
+}
+
+void resetCacheDir()
+{
+  const auto dir = cacheDir();
+  std::error_code ec;
+  std::filesystem::remove_all(dir, ec);
+  std::filesystem::create_directories(dir, ec);
+}
+
+bool waitForCacheWithNode(const std::filesystem::path& path, const std::string& nodeName,
+                          std::chrono::milliseconds timeout)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    std::ifstream in(path);
+    if (in) {
+      std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+      if (contents.find(nodeName) != std::string::npos)
+        return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  return false;
+}
+
+miniros::Error startMaster(miniros::Launcher& launcher, int port)
+{
+  // Same sanitizer policy as manage-master: keep reporting races, do not kill
+  // the private master on the first TSan warning.
+  if (std::getenv("TSAN_OPTIONS") || std::getenv("ASAN_OPTIONS")) {
+    launcher.env("TSAN_OPTIONS",
+                 "halt_on_error=0:abort_on_error=0:second_deadlock_stack=1:history_size=7");
+    launcher.env("ASAN_OPTIONS", "halt_on_error=0:abort_on_error=0");
+  }
+
+  const auto logDir = cacheDir() / "logs";
+  std::error_code ec;
+  std::filesystem::create_directories(logDir, ec);
+  const auto crashLog = (logDir / "miniroscore.crash").string();
+  const auto consoleLog = (logDir / "miniroscore.console.log").string();
+  // Stable advertised host so cache URI matches post-restart re-registrations.
+  launcher.env("ROS_HOSTNAME", "127.0.0.1")
+          .env("MINIROS_MASTER_LOG_DIR", logDir.string().c_str())
+          .env("MINIROS_CRASH_LOG", crashLog.c_str())
+          .env("MINIROS_MASTER_CONSOLE_LOG", consoleLog.c_str());
+
+  const std::vector<std::string> args = {
+    "-p", std::to_string(port),
+    "--dir", cacheDir().string(),
+    "--rosout", "false",
+    "--node_check_period", "0",
+  };
+  const int flags = miniros::Launcher::FLAG_DETACHED | miniros::Launcher::FLAG_NOTIFY;
+  if (miniros::Error err = launcher.start(executable("miniroscore"), args, flags); !err)
+    return err;
+
+  miniros::ChildReady ready;
+  if (miniros::Error err = launcher.waitReady(&ready, miniros::WallDuration(8.0)); !err)
+    return err;
+  if (ready.rpcPort != 0 && ready.rpcPort != port)
+    return miniros::Error::InvalidResponse;
+  return miniros::Error::Ok;
+}
+
+} // namespace
+
+class MasterCacheTest : public ::testing::Test {
+protected:
+  void TearDown() override
+  {
+    if (miniros::isInitialized()) {
+      miniros::shutdown();
+    }
+    pub_.stopAndWait(miniros::WallDuration(5.0));
+    master2_.stopAndWait(miniros::WallDuration(5.0));
+    master_.stopAndWait(miniros::WallDuration(5.0));
+  }
+
+  miniros::Launcher master_;
+  miniros::Launcher master2_;
+  miniros::Launcher pub_;
+};
+
+TEST_F(MasterCacheTest, PublisherSurvivesMasterRestartFromCache)
+{
+  resetCacheDir();
+  const std::string masterUri = "http://127.0.0.1:" + std::to_string(kMasterPort);
+
+  ASSERT_EQ(startMaster(master_, kMasterPort), miniros::Error::Ok);
+
+  ASSERT_EQ(pub_.env("ROS_MASTER_URI", masterUri.c_str())
+              .env("ROS_HOSTNAME", "127.0.0.1")
+              .start(executable("basic-test_master_cache_pub"), {},
+                     miniros::Launcher::FLAG_NOTIFY),
+            miniros::Error::Ok);
+
+  miniros::ChildReady pubReady;
+  ASSERT_EQ(pub_.waitReady(&pubReady, miniros::WallDuration(10.0)), miniros::Error::Ok)
+      << "publisher should finish advertise/notify while the first master is up";
+  ASSERT_TRUE(pub_.running());
+
+  // Wait until the publisher is actually present in the on-disk snapshot.
+  ASSERT_TRUE(waitForCacheWithNode(cacheFile(kMasterPort), kPubNode, std::chrono::seconds(5)))
+      << "expected " << kPubNode << " in " << cacheFile(kMasterPort);
+
+  // Clean stop so MasterCache::flush writes the latest snapshot.
+  master_.stopAndWait(miniros::WallDuration(5.0));
+  ASSERT_FALSE(master_.running());
+  ASSERT_TRUE(pub_.running()) << "publisher must survive master restart";
+  ASSERT_TRUE(waitForCacheWithNode(cacheFile(kMasterPort), kPubNode, std::chrono::seconds(1)))
+      << "cache must still contain publisher after clean master stop";
+
+  // Restart master from the same cache dir/port (new Launcher — not assignable).
+  ASSERT_EQ(startMaster(master2_, kMasterPort), miniros::Error::Ok);
+  ASSERT_TRUE(pub_.running()) << "publisher must still be alive after master restart";
+
+  // Give MasterCache time to finish getPid/getPublications before attaching a
+  // subscriber (restore is asynchronous on the master update loop).
+  miniros::WallDuration(0.5).sleep();
+
+  // Subscriber side in this process: discover the restored publisher and take
+  // the latched message.
+  setenv("ROS_MASTER_URI", masterUri.c_str(), 1);
+  setenv("ROS_HOSTNAME", "127.0.0.1", 1);
+  int argc = 1;
+  char arg0[] = "basic-test_master_cache";
+  char* argv[] = {arg0, nullptr};
+  miniros::init(argc, argv, "cache_test_sub",
+                miniros::init_options::AnonymousName | miniros::init_options::NoRosout |
+                    miniros::init_options::NoSimTime);
+
+  // Wait until restore re-learns the publisher (getPublications → register).
+  {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    bool sawTopic = false;
+    while (std::chrono::steady_clock::now() < deadline) {
+      std::vector<miniros::TopicInfo> topics;
+      if (auto link = miniros::getMasterLink(); link && link->getTopics(topics)) {
+        for (const auto& t : topics) {
+          if (t.name == std::string("/") + kTopic || t.name == kTopic) {
+            sawTopic = true;
+            break;
+          }
+        }
+      }
+      if (sawTopic)
+        break;
+      miniros::WallDuration(0.1).sleep();
+    }
+    ASSERT_TRUE(sawTopic) << "restarted master should advertise topic " << kTopic
+                          << " after cache restore of surviving publisher";
+  }
+
+  std::atomic<int> got{0};
+  std::string last;
+  miniros::NodeHandle nh;
+  miniros::Subscriber sub = nh.subscribe<std_msgs::String>(
+      kTopic, 1, [&](const std_msgs::String::ConstPtr& msg) {
+        last = msg->data;
+        got.fetch_add(1);
+      });
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (got.load() == 0 && std::chrono::steady_clock::now() < deadline) {
+    miniros::spinOnce();
+    miniros::WallDuration(0.05).sleep();
+  }
+
+  ASSERT_GE(got.load(), 1) << "subscriber should receive latched message from restored publisher";
+  EXPECT_EQ(last, kPayload);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/roscpp/basic/test_master_cache.cpp
+++ b/test/roscpp/basic/test_master_cache.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include "miniros/launcher.h"
+#include "miniros/platform.h"
 #include "miniros/ros.h"
 #include "std_msgs/String.hxx"
 
@@ -176,8 +177,8 @@ TEST_F(MasterCacheTest, PublisherSurvivesMasterRestartFromCache)
 
   // Subscriber side in this process: discover the restored publisher and take
   // the latched message.
-  setenv("ROS_MASTER_URI", masterUri.c_str(), 1);
-  setenv("ROS_HOSTNAME", "127.0.0.1", 1);
+  ASSERT_TRUE(miniros::set_environment_variable("ROS_MASTER_URI", masterUri.c_str()));
+  ASSERT_TRUE(miniros::set_environment_variable("ROS_HOSTNAME", "127.0.0.1"));
   int argc = 1;
   char arg0[] = "basic-test_master_cache";
   char* argv[] = {arg0, nullptr};

--- a/test/roscpp/basic/test_master_cache_pub.cpp
+++ b/test/roscpp/basic/test_master_cache_pub.cpp
@@ -1,0 +1,61 @@
+//
+// Long-lived latching publisher for master-cache restore tests.
+// Advertises, publishes one latched message, notifies readiness, then spins
+// so a restarted master can re-query getPublications and a later subscriber
+// can still connect.
+//
+
+#include <chrono>
+#include <cstdlib>
+#include <string>
+
+#include "miniros/common.h"
+#include "miniros/ros.h"
+#include "std_msgs/String.hxx"
+
+namespace {
+
+constexpr const char* kTopic = "cache_test_chatter";
+constexpr const char* kPayload = "hello-from-cached-publisher";
+
+double spinTimeoutSec()
+{
+  if (const char* env = std::getenv("MASTER_CACHE_PUB_TIMEOUT")) {
+    char* end = nullptr;
+    const double v = std::strtod(env, &end);
+    if (end != env && v > 0.0)
+      return v;
+  }
+  return 60.0;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+  miniros::init(argc, argv, "cache_test_pub",
+                miniros::init_options::NoRosout | miniros::init_options::NoSimTime);
+
+  miniros::NodeHandle nh;
+  miniros::Publisher pub = nh.advertise<std_msgs::String>(kTopic, 1, true /* latch */);
+
+  std_msgs::String msg;
+  msg.data = kPayload;
+  pub.publish(msg);
+
+  miniros::NodeNotifyInfo info;
+  if (miniros::Error err = miniros::notifyNodeStarted(info); !err) {
+    MINIROS_ERROR("cache_test_pub: notifyNodeStarted failed: %s", err.toString());
+    return EXIT_FAILURE;
+  }
+
+  miniros::Rate rate(20);
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::duration<double>(spinTimeoutSec());
+  while (miniros::ok() && std::chrono::steady_clock::now() < deadline) {
+    miniros::spinOnce();
+    rate.sleep();
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
**miniroscore** now saves the list of nodes (**NodeRef** instance), their state and URI.
It will try to restore list of nodes and then request all information about subscriptions, publications and services directly from them. 

This will help in cases when **miniroscore** crashes for some reason, while nodes are staying alive.